### PR TITLE
Feature/sim 1206/angle api

### DIFF
--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -3,7 +3,8 @@ import palpy
 from lsst.sims.utils import arcsecFromRadians, cartesianFromSpherical, sphericalFromCartesian
 from lsst.sims.utils import haversine
 
-__all__ = ["_applyPrecession", "_applyProperMotion", "_appGeoFromICRS", "_observedFromAppGeo",
+__all__ = ["_applyPrecession", "applyPrecession",
+           "_applyProperMotion", "_appGeoFromICRS", "_observedFromAppGeo",
            "_observedFromICRS", "_calculatePupilCoordinates", "refractionCoefficients",
            "applyRefraction", "_raDecFromPupilCoordinates"]
 
@@ -71,9 +72,41 @@ def applyRefraction(zenithDistance, tanzCoeff, tan3zCoeff):
     return refractedZenith
 
 
-def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
+def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     """
     applyPrecession() applies precesion and nutation to coordinates between two epochs.
+    Accepts RA and dec as inputs.  Returns corrected RA and dec (in degrees).
+
+    Assumes FK5 as the coordinate system
+    units:  ra_in (radians), dec_in (radians)
+
+    The precession-nutation matrix is calculated by the palpy.prenut method
+    which uses the IAU 2006/2000A model
+
+    @param [in] ra in degrees
+
+    @param [in] dec in degrees
+
+    @param [in] epoch is the epoch of the mean equinox (in years; default 2000)
+
+    @param [in] mjd is the MJD of the observation
+
+    @param [out] raOut is ra corrected for precession and nutation in degrees
+
+    @param [out] decOut is dec corrected for precession and nutation in degrees
+
+    """
+
+    raOut, decOut = _applyPrecession(numpy.radians(ra), numpy.radians(dec),
+                                     epoch=epoch, mjd=mjd)
+
+    return numpy.degrees(raOut), numpy.degrees(decOut)
+
+
+
+def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
+    """
+    _applyPrecession() applies precesion and nutation to coordinates between two epochs.
     Accepts RA and dec as inputs.  Returns corrected RA and dec (in radians).
 
     Assumes FK5 as the coordinate system

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -10,8 +10,8 @@ __all__ = ["applyRefraction", "refractionCoefficients",
            "_appGeoFromICRS", "appGeoFromICRS",
            "_observedFromAppGeo", "observedFromAppGeo",
            "_observedFromICRS", "observedFromICRS",
-           "_calculatePupilCoordinates", "calculatePupilCoordinates",
-           "_raDecFromPupilCoordinates", "raDecFromPupilCoordinates"]
+           "_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
+           "_raDecFromPupilCoords", "raDecFromPupilCoords"]
 
 
 
@@ -753,7 +753,7 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
 
 
-def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
+def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     """
     @param [in] xPupil -- pupil coordinates in radians
 
@@ -770,13 +770,13 @@ def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
     @param [out] decOut -- the declination in degrees (a numpy array)
     """
 
-    raOut, decOut = _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=obs_metadata,
+    raOut, decOut = _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=obs_metadata,
                                                epoch=epoch)
 
     return numpy.degrees(raOut), numpy.degrees(decOut)
 
 
-def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
+def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     """
     @param [in] xPupil -- pupil coordinates in radians
 
@@ -794,17 +794,17 @@ def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
     """
 
     if obs_metadata is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoordinates without obs_metadata")
+        raise RuntimeError("Cannot call raDecFromPupilCoords without obs_metadata")
 
     if epoch is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoordinates; epoch is None")
+        raise RuntimeError("Cannot call raDecFromPupilCoords; epoch is None")
 
     if obs_metadata.rotSkyPos is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoordinates without rotSkyPos " + \
+        raise RuntimeError("Cannot call raDecFromPupilCoords without rotSkyPos " + \
                            "in obs_metadata")
 
     if obs_metadata.unrefractedRA is None or obs_metadata.unrefractedDec is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoordinates "+ \
+        raise RuntimeError("Cannot call raDecFromPupilCoords "+ \
                           "without unrefractedRA, unrefractedDec in obs_metadata")
 
     if obs_metadata.mjd is None:
@@ -812,11 +812,11 @@ def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
                            "in obs_metadata")
 
     if len(xPupil)!=len(yPupil):
-        raise RuntimeError("You passed %d RAs but %d Decs into raDecFromPupilCoordinates" % \
+        raise RuntimeError("You passed %d RAs but %d Decs into raDecFromPupilCoords" % \
                            (len(raObj), len(decObj)))
 
 
-    #This is the same as theta in calculatePupilCoordinates, except without the minus sign.
+    #This is the same as theta in pupilCoordsFromRaDec, except without the minus sign.
     #This is because we will be reversing the rotation performed in that other method.
     theta = -1.0*obs_metadata._rotSkyPos
 
@@ -846,7 +846,7 @@ def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
 
 
 
-def calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
+def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -872,11 +872,11 @@ def calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
     radians and whose second row is the y coordinate in radians
     """
 
-    return _calculatePupilCoordinates(numpy.radians(ra_in), numpy.radians(dec_in),
+    return _pupilCoordsFromRaDec(numpy.radians(ra_in), numpy.radians(dec_in),
                                       obs_metadata=obs_metadata, epoch=epoch)
 
 
-def _calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
+def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -903,16 +903,16 @@ def _calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
     """
 
     if obs_metadata is None:
-        raise RuntimeError("Cannot call calculatePupilCoordinates without obs_metadata")
+        raise RuntimeError("Cannot call pupilCoordsFromRaDec without obs_metadata")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("Cannot call calculatePupilCoordinates; obs_metadata.mjd is None")
+        raise RuntimeError("Cannot call pupilCoordsFromRaDec; obs_metadata.mjd is None")
 
     if epoch is None:
-        raise RuntimeError("Cannot call calculatePupilCoordinates; epoch is None")
+        raise RuntimeError("Cannot call pupilCoordsFromRaDec; epoch is None")
 
     if len(ra_in)!=len(dec_in):
-        raise RuntimeError("You passed %d RAs but %d Decs to calculatePupilCoordinates" % (len(ra_in), len(dec_in)))
+        raise RuntimeError("You passed %d RAs but %d Decs to pupilCoordsFromRaDec" % (len(ra_in), len(dec_in)))
 
     if obs_metadata.rotSkyPos is None:
         #there is no observation meta data on which to base astrometry

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -7,7 +7,7 @@ from lsst.sims.utils import haversine
 __all__ = ["_applyPrecession", "applyPrecession",
            "_applyProperMotion", "applyProperMotion",
            "_appGeoFromICRS", "appGeoFromICRS",
-           "_observedFromAppGeo",
+           "_observedFromAppGeo", "observedFromAppGeo",
            "_observedFromICRS", "_calculatePupilCoordinates", "refractionCoefficients",
            "applyRefraction", "_raDecFromPupilCoordinates"]
 
@@ -444,6 +444,61 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     return raOut,decOut
 
+
+def observedFromAppGeo(ra, dec, includeRefraction = True,
+                       altAzHr=False, wavelength=0.5, obs_metadata = None):
+    """
+    Convert apparent geocentric (RA, Dec)-like coordinates to observed
+    (RA, Dec)-like coordinates.  More specifically, apply refraction and
+    diurnal aberration.
+
+    Uses PAL aoppa routines
+
+    This will call palpy.aopqk
+
+    @param [in] ra is geocentric apparent RA (degrees).  Must be a numpy array.
+
+    @param [in] dec is geocentric apparent Dec (degrees).  Must be a numpy array.
+
+    @param [in] includeRefraction is a boolean to turn refraction on and off
+
+    @param [in] altAzHr is a boolean indicating whether or not to return altitude
+    and azimuth
+
+    @param [in] wavelength is effective wavelength in microns (default: 0.5)
+
+    @param [in] obs_metadata is an ObservationMetaData characterizing the
+    observation (optional; if not included, the code will try to set it from
+    self assuming it is in an InstanceCatalog daughter class.  If that is not
+    the case, an exception will be raised.)
+
+    @param [out] raOut is oberved RA (degrees)
+
+    @param [out] decOut is observed Dec (degrees)
+
+    @param [out] alt is altitude angle (only returned if altAzHr == True) (degrees)
+
+    @param [out] az is azimuth angle (only returned if altAzHr == True) (degrees)
+
+    """
+
+    if altAzHr:
+        raOut, decOut, \
+        altOut, azOut = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+                                            includeRefraction=includeRefraction,
+                                            altAzHr=altAzHr, wavelength=wavelength,
+                                            obs_metadata=obs_metadata)
+
+        return numpy.degrees(raOut), numpy.degrees(decOut), \
+               numpy.degrees(altOut), numpy.degrees(azOut)
+
+    else:
+        raOut, decOut = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+                                            includeRefraction=includeRefraction,
+                                            altAzHr=altAzHr, wavelength=wavelength,
+                                            obs_metadata=obs_metadata)
+
+        return numpy.degrees(raOut), numpy.degrees(decOut)
 
 
 def _observedFromAppGeo(ra, dec, includeRefraction = True,

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -3,9 +3,9 @@ import palpy
 from lsst.sims.utils import arcsecFromRadians, cartesianFromSpherical, sphericalFromCartesian
 from lsst.sims.utils import haversine
 
-__all__ = ["applyPrecession", "applyProperMotion", "appGeoFromICRS", "observedFromAppGeo",
-           "observedFromICRS", "calculatePupilCoordinates", "refractionCoefficients",
-           "applyRefraction", "raDecFromPupilCoordinates"]
+__all__ = ["_applyPrecession", "_applyProperMotion", "_appGeoFromICRS", "_observedFromAppGeo",
+           "_observedFromICRS", "_calculatePupilCoordinates", "refractionCoefficients",
+           "applyRefraction", "_raDecFromPupilCoordinates"]
 
 
 
@@ -71,7 +71,7 @@ def applyRefraction(zenithDistance, tanzCoeff, tan3zCoeff):
     return refractedZenith
 
 
-def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
+def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     """
     applyPrecession() applies precesion and nutation to coordinates between two epochs.
     Accepts RA and dec as inputs.  Returns corrected RA and dec (in radians).
@@ -82,17 +82,17 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     The precession-nutation matrix is calculated by the palpy.prenut method
     which uses the IAU 2006/2000A model
 
-    @param [in] ra
+    @param [in] ra in radians
 
-    @param [in] dec
+    @param [in] dec in radians
 
     @param [in] epoch is the epoch of the mean equinox (in years; default 2000)
 
     @param [in] mjd is the MJD of the observation
 
-    @param [out] raOut is ra corrected for precession and nutation
+    @param [out] raOut is ra corrected for precession and nutation in radians
 
-    @param [out] decOut is dec corrected for precession and nutation
+    @param [out] decOut is dec corrected for precession and nutation in radians
 
     """
 
@@ -121,7 +121,7 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
 
 
 
-def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
+def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
                       epoch=2000.0, mjd=None):
     """Applies proper motion between two epochs.
 
@@ -153,9 +153,9 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
     @param [in] mjd is the MJD of the actual observation
 
-    @param [out] raOut is corrected ra
+    @param [out] raOut is corrected ra in radians
 
-    @param [out] decOut is corrected dec
+    @param [out] decOut is corrected dec in radians
 
     """
 
@@ -208,7 +208,7 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
 
 
-def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
+def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
                    v_rad=None, epoch=2000.0, mjd = None):
     """
     Convert the mean position (RA, Dec) in the International Celestial Reference
@@ -299,7 +299,7 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
 
 
-def observedFromAppGeo(ra, dec, includeRefraction = True,
+def _observedFromAppGeo(ra, dec, includeRefraction = True,
                        altAzHr=False, wavelength=0.5, obs_metadata = None):
     """
     Convert apparent geocentric (RA, Dec)-like coordinates to observed
@@ -427,7 +427,7 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
     return raOut, decOut
 
 
-def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
+def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
                      obs_metadata=None, epoch=None, includeRefraction=True):
     """
     Convert mean position (RA, Dec) in the International Celestial Reference Frame
@@ -458,9 +458,9 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
 
     @param [in] includeRefraction toggles whether or not to correct for refraction
 
-    @param [out] ra_out RA corrected for all included effects
+    @param [out] ra_out RA in radians corrected for all included effects
 
-    @param [out] dec_out Dec corrected for all included effects
+    @param [out] dec_out Dec in radians corrected for all included effects
 
     """
 
@@ -477,16 +477,16 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
         raise RuntimeError("You passed %d RAs but %d Decs to observedFromICRS" % \
                            (len(ra), len(dec)))
 
-    ra_apparent, dec_apparent = appGeoFromICRS(ra, dec, pm_ra = pm_ra,
+    ra_apparent, dec_apparent = _appGeoFromICRS(ra, dec, pm_ra = pm_ra,
              pm_dec = pm_dec, parallax = parallax, v_rad = v_rad, epoch = epoch, mjd=obs_metadata.mjd)
 
-    ra_out, dec_out = observedFromAppGeo(ra_apparent, dec_apparent, obs_metadata=obs_metadata,
+    ra_out, dec_out = _observedFromAppGeo(ra_apparent, dec_apparent, obs_metadata=obs_metadata,
                                                includeRefraction = includeRefraction)
 
     return numpy.array([ra_out,dec_out])
 
 
-def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
+def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
     """
     @param [in] xPupil -- pupil coordinates in radians
 
@@ -535,7 +535,7 @@ def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
     pointingDec=numpy.array([obs_metadata._unrefractedDec])
 
     #transform from mean, ICRS pointing coordinates to observed pointing coordinates
-    boreRA, boreDec = observedFromICRS(pointingRA, pointingDec, epoch=epoch, obs_metadata=obs_metadata)
+    boreRA, boreDec = _observedFromICRS(pointingRA, pointingDec, epoch=epoch, obs_metadata=obs_metadata)
 
     x_g = xPupil*numpy.cos(theta) - yPupil*numpy.sin(theta)
     y_g = xPupil*numpy.sin(theta) + yPupil*numpy.cos(theta)
@@ -555,7 +555,7 @@ def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
     return numpy.array(raOut), numpy.array(decOut)
 
 
-def calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
+def _calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -605,7 +605,7 @@ def calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
     # convert pointing RA, Dec from above-the-atmosphere mean RA, Dec to observed RA, Dec
     pointingRA=numpy.array([obs_metadata._unrefractedRA])
     pointingDec=numpy.array([obs_metadata._unrefractedDec])
-    boreRA, boreDec = observedFromICRS(pointingRA, pointingDec, epoch=epoch, obs_metadata=obs_metadata)
+    boreRA, boreDec = _observedFromICRS(pointingRA, pointingDec, epoch=epoch, obs_metadata=obs_metadata)
 
     #palpy.ds2tp performs the gnomonic projection on ra_in and dec_in
     #with a tangent point at (trueRA, trueDec)

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -10,7 +10,7 @@ __all__ = ["applyRefraction", "refractionCoefficients",
            "_appGeoFromICRS", "appGeoFromICRS",
            "_observedFromAppGeo", "observedFromAppGeo",
            "_observedFromICRS", "observedFromICRS",
-           "_calculatePupilCoordinates",
+           "_calculatePupilCoordinates", "calculatePupilCoordinates",
            "_raDecFromPupilCoordinates", "raDecFromPupilCoordinates"]
 
 
@@ -843,6 +843,37 @@ def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
         decOut.append(dd)
 
     return numpy.array(raOut), numpy.array(decOut)
+
+
+
+def calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):
+    """
+    Take an input RA and dec from the sky and convert it to coordinates
+    on the focal plane.
+
+    This uses PAL's gnonomonic projection routine which assumes that the focal
+    plane is perfectly flat.  The output is in Cartesian coordinates, assuming
+    that the Celestial Sphere is a unit sphere.
+
+    @param [in] ra_in is a numpy array of RAs in degrees
+
+    @param [in] dec_in in degrees
+
+    @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
+    telescope location and pointing (optional; if not provided, the method will try to
+    get it from the InstanceCatalog member variable, assuming this is part of an
+    InstanceCatalog)
+
+    @param [in] epoch is the epoch of mean ra and dec in julian years (optional; if not
+    provided, this method will try to get it from the db_obj member variable, assuming this
+    method is part of an InstanceCatalog)
+
+    @param [out] returns a numpy array whose first row is the x coordinate on the pupil in
+    radians and whose second row is the y coordinate in radians
+    """
+
+    return _calculatePupilCoordinates(numpy.radians(ra_in), numpy.radians(dec_in),
+                                      obs_metadata=obs_metadata, epoch=epoch)
 
 
 def _calculatePupilCoordinates(ra_in, dec_in, obs_metadata=None, epoch=None):

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -4,13 +4,14 @@ from lsst.sims.utils import arcsecFromRadians, cartesianFromSpherical, spherical
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.utils import haversine
 
-__all__ = ["_applyPrecession", "applyPrecession",
+__all__ = ["applyRefraction", "refractionCoefficients",
+           "_applyPrecession", "applyPrecession",
            "_applyProperMotion", "applyProperMotion",
            "_appGeoFromICRS", "appGeoFromICRS",
            "_observedFromAppGeo", "observedFromAppGeo",
            "_observedFromICRS", "observedFromICRS",
-           "_calculatePupilCoordinates", "refractionCoefficients",
-           "applyRefraction", "_raDecFromPupilCoordinates"]
+           "_calculatePupilCoordinates",
+           "_raDecFromPupilCoordinates", "raDecFromPupilCoordinates"]
 
 
 
@@ -749,6 +750,30 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
                                                includeRefraction = includeRefraction)
 
     return numpy.array([ra_out,dec_out])
+
+
+
+def raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):
+    """
+    @param [in] xPupil -- pupil coordinates in radians
+
+    @param [in] yPupil -- pupil coordinates in radians
+
+    @param [in] obs_metadata -- an instantiation of ObservationMetaData characterizing
+    the state of the telescope
+
+    @param [in] epoch -- julian epoch of the mean equinox used for the coordinate
+    transforations (in years)
+
+    @param [out] raOut -- the right ascension in degrees (a numpy array)
+
+    @param [out] decOut -- the declination in degrees (a numpy array)
+    """
+
+    raOut, decOut = _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=obs_metadata,
+                                               epoch=epoch)
+
+    return numpy.degrees(raOut), numpy.degrees(decOut)
 
 
 def _raDecFromPupilCoordinates(xPupil, yPupil, obs_metadata=None, epoch=None):

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -96,16 +96,16 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
 
     @param [in] mjd is the MJD of the observation
 
-    @param [out] raOut is ra corrected for precession and nutation in degrees
-
-    @param [out] decOut is dec corrected for precession and nutation in degrees
+    @param [out] a 2-D numpy array in which the first row is the RA
+    corrected for precession and nutation and the second row is the
+    Dec corrected for precession and nutation (both in degrees)
 
     """
 
-    raOut, decOut = _applyPrecession(numpy.radians(ra), numpy.radians(dec),
-                                     epoch=epoch, mjd=mjd)
+    output = _applyPrecession(numpy.radians(ra), numpy.radians(dec),
+                              epoch=epoch, mjd=mjd)
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 
@@ -128,10 +128,9 @@ def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
 
     @param [in] mjd is the MJD of the observation
 
-    @param [out] raOut is ra corrected for precession and nutation in radians
-
-    @param [out] decOut is dec corrected for precession and nutation in radians
-
+    @param [out] a 2-D numpy array in which the first row is the RA
+    corrected for precession and nutation and the second row is the
+    Dec corrected for precession and nutation (both in radians)
     """
 
     if hasattr(ra, '__len__'):
@@ -155,7 +154,7 @@ def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     xyz =  numpy.dot(rmat,xyz.transpose()).transpose()
 
     raOut,decOut = sphericalFromCartesian(xyz)
-    return raOut,decOut
+    return numpy.array([raOut,decOut])
 
 
 def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
@@ -190,19 +189,18 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
     @param [in] mjd is the MJD of the actual observation
 
-    @param [out] raOut is corrected ra in degrees
-
-    @param [out] decOut is corrected dec in degrees
+    @param [out] a 2-D numpy array in which the first row is the RA corrected
+    for proper motion and the second row is the Dec corrected for proper motion
+    (both in degrees)
     """
 
-    raOut, \
-    decOut = _applyProperMotion(numpy.radians(ra), numpy.radians(dec),
+    output = _applyProperMotion(numpy.radians(ra), numpy.radians(dec),
                                 radiansFromArcsec(pm_ra),
                                 radiansFromArcsec(pm_dec),
                                 radiansFromArcsec(parallax),
                                 v_rad, epoch=epoch, mjd=mjd)
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
@@ -237,9 +235,9 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
     @param [in] mjd is the MJD of the actual observation
 
-    @param [out] raOut is corrected ra in radians
-
-    @param [out] decOut is corrected dec in radians
+    @param [out] a 2-D numpy array in which the first row is the RA corrected
+    for proper motion and the second row is the Dec corrected for proper motion
+    (both in radians)
 
     """
 
@@ -288,7 +286,7 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     else:
         raOut, decOut = palpy.pm(ra, dec, pm_ra_corrected, pm_dec, parallaxArcsec, v_rad, epoch, julianEpoch)
 
-    return raOut,decOut
+    return numpy.array([raOut,decOut])
 
 
 
@@ -327,10 +325,9 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     @param[in] MJD is the date of the observation
 
-    @param [out] raOut is apparent geocentric RA-like coordinate in degrees
-
-    @param [out] decOut is apparent geocentric Dec-like coordinate in degrees
-
+    @param [out] a 2-D numpy array in which the first row is the apparent
+    geocentric RA and the second row is the apparent geocentric Dec
+    coordinate (both in degrees)
     """
 
     if pm_ra is not None:
@@ -348,13 +345,12 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     else:
         px_in = None
 
-    raOut, \
-    decOut = _appGeoFromICRS(numpy.radians(ra), numpy.radians(dec),
+    output = _appGeoFromICRS(numpy.radians(ra), numpy.radians(dec),
                              pm_ra=pm_ra_in, pm_dec=pm_dec_in,
                              parallax=px_in, v_rad=v_rad, epoch=epoch, mjd=mjd)
 
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
@@ -392,10 +388,9 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     @param[in] MJD is the date of the observation
 
-    @param [out] raOut is apparent geocentric RA-like coordinate in radians
-
-    @param [out] decOut is apparent geocentric Dec-like coordinate in radians
-
+    @param [out] a 2-D numpy array in which the first row is the apparent
+    geocentric RA-like coordinate and the second row is the apparent
+    geocentric Dec-like coordinate (both in radians)
     """
 
     if mjd is None:
@@ -444,7 +439,7 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     raOut,decOut = palpy.mapqkVector(ra,dec,pm_ra_corrected,pm_dec,arcsecFromRadians(parallax),v_rad,prms)
 
-    return raOut,decOut
+    return numpy.array([raOut,decOut])
 
 
 def observedFromAppGeo(ra, dec, includeRefraction = True,
@@ -474,33 +469,30 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
     self assuming it is in an InstanceCatalog daughter class.  If that is not
     the case, an exception will be raised.)
 
-    @param [out] raOut is oberved RA (degrees)
+    @param [out] a 2-D numpy array in which the first row is the observed RA
+    and the second row is the observed Dec (both in degrees)
 
-    @param [out] decOut is observed Dec (degrees)
-
-    @param [out] alt is altitude angle (only returned if altAzHr == True) (degrees)
-
-    @param [out] az is azimuth angle (only returned if altAzHr == True) (degrees)
-
+    @param [out] a 2-D numpy array in which the first row is the altitude
+    and the second row is the azimuth (both in degrees).  Only returned
+    if altAzHr == True.
     """
 
     if altAzHr:
-        raOut, decOut, \
-        altOut, azOut = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+        raDec, \
+        altAz = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
                                             includeRefraction=includeRefraction,
                                             altAzHr=altAzHr, wavelength=wavelength,
                                             obs_metadata=obs_metadata)
 
-        return numpy.degrees(raOut), numpy.degrees(decOut), \
-               numpy.degrees(altOut), numpy.degrees(azOut)
+        return numpy.degrees(raDec), numpy.degrees(altAz)
 
     else:
-        raOut, decOut = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+        output = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
                                             includeRefraction=includeRefraction,
                                             altAzHr=altAzHr, wavelength=wavelength,
                                             obs_metadata=obs_metadata)
 
-        return numpy.degrees(raOut), numpy.degrees(decOut)
+        return numpy.degrees(output)
 
 
 def _observedFromAppGeo(ra, dec, includeRefraction = True,
@@ -530,13 +522,12 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
     self assuming it is in an InstanceCatalog daughter class.  If that is not
     the case, an exception will be raised.)
 
-    @param [out] raOut is oberved RA (radians)
+    @param [out] a 2-D numpy array in which the first row is the observed RA
+    and the second row is the observed Dec (both in radians)
 
-    @param [out] decOut is observed Dec (radians)
-
-    @param [out] alt is altitude angle (only returned if altAzHr == True) (radians)
-
-    @param [out] az is azimuth angle (only returned if altAzHr == True) (radians)
+    @param [out] a 2-D numpy array in which the first row is the altitude
+    and the second row is the azimuth (both in radians).  Only returned
+    if altAzHr == True.
 
     """
 
@@ -627,8 +618,8 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
         #palpy.de2h converts equatorial to horizon coordinates
         #
         az, alt = palpy.de2hVector(hourAngle,decOut,obs_metadata.site.latitude)
-        return raOut, decOut, alt, az
-    return raOut, decOut
+        return numpy.array([raOut, decOut]), numpy.array([alt, az])
+    return numpy.array([raOut, decOut])
 
 
 def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
@@ -662,10 +653,8 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
 
     @param [in] includeRefraction toggles whether or not to correct for refraction
 
-    @param [out] ra_out RA in radians corrected for all included effects
-
-    @param [out] dec_out Dec in radians corrected for all included effects
-
+    @param [out] a 2-D numpy array in which the first row is the observed
+    RA and the second row is the observed Dec (both in degrees)
     """
 
     if pm_ra is not None:
@@ -683,13 +672,12 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
     else:
         parallax_in = None
 
-    raOut, \
-    decOut = _observedFromICRS(numpy.radians(ra), numpy.radians(dec),
+    output = _observedFromICRS(numpy.radians(ra), numpy.radians(dec),
                                pm_ra=pm_ra_in, pm_dec=pm_dec_in, parallax=parallax_in,
                                v_rad=v_rad, obs_metadata=obs_metadata, epoch=epoch,
                                includeRefraction=includeRefraction)
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 
@@ -724,9 +712,8 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
     @param [in] includeRefraction toggles whether or not to correct for refraction
 
-    @param [out] ra_out RA in radians corrected for all included effects
-
-    @param [out] dec_out Dec in radians corrected for all included effects
+    @param [out] a 2-D numpy array in which the first row is the observed
+    RA and the second row is the observed Dec (both in radians)
 
     """
 
@@ -765,15 +752,14 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     @param [in] epoch -- julian epoch of the mean equinox used for the coordinate
     transforations (in years)
 
-    @param [out] raOut -- the right ascension in degrees (a numpy array)
-
-    @param [out] decOut -- the declination in degrees (a numpy array)
+    @param [out] a 2-D numpy array in which the first row is RA and the second
+    row is Dec (both in degrees)
     """
 
-    raOut, decOut = _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=obs_metadata,
+    output = _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=obs_metadata,
                                                epoch=epoch)
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
@@ -788,9 +774,8 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     @param [in] epoch -- julian epoch of the mean equinox used for the coordinate
     transforations (in years)
 
-    @param [out] raOut -- the right ascension in radians (a numpy array)
-
-    @param [out] decOut -- the declination in radians (a numpy array)
+    @param [out] a 2-D numpy array in which the first row is RA and the second
+    row is Dec (both in radians)
     """
 
     if obs_metadata is None:
@@ -842,7 +827,7 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
         raOut.append(rr)
         decOut.append(dd)
 
-    return numpy.array(raOut), numpy.array(decOut)
+    return numpy.array([raOut, decOut])
 
 
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -388,7 +388,7 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     xPupilList = numpy.array(xPupilList)
     yPupilList = numpy.array(yPupilList)
 
-    return xPupilList, yPupilList
+    return numpy.array([xPupilList, yPupilList])
 
 
 def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -8,7 +8,7 @@ __all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
            "pixelCoordsFromPupilCoords", "pixelCoordsFromRaDec", "_pixelCoordsFromRaDec",
            "focalPlaneCoordsFromPupilCoords", "focalPlaneCoordsFromRaDec", "_focalPlaneCoordsFromRaDec",
            "pupilCoordsFromPixelCoords",
-           "_raDecFromPixelCoordinates"]
+           "raDecFromPixelCoords", "_raDecFromPixelCoords"]
 
 
 def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
@@ -390,8 +390,46 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     return xPupilList, yPupilList
 
 
-def _raDecFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
-                              obs_metadata=None, epoch=None, includeDistortion=True):
+def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
+                         obs_metadata=None, epoch=None, includeDistortion=True):
+    """
+    Convert pixel coordinates into observed RA, Dec
+
+    @param [in] xPixList is a numpy array of x pixel coordinates
+
+    @param [in] yPixList is a numpy array of y pixel coordinates
+
+    @param [in] chipNameList is a numpy array of chip names (corresponding to the points
+    in xPixList and yPixList)
+
+    @param [in] camera is an afw.CameraGeom.camera object defining the camera
+
+    @param [in] obs_metadata is an ObservationMetaData defining the pointing
+
+    @param [in] epoch is the mean epoch in years of the celestial coordinate system
+
+    @param [in] includeDistortion is a boolean.  If True (default), then this method will
+    expect the true pixel coordinates with optical distortion included.  If False, this
+    method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+    estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+    details.
+
+    @param [out] ra is a numpy array of observed RA in degrees
+
+    @param [out] dec is a numpy array of observed Dec in degrees
+
+    Note: to see what is mean by 'observed' ra/dec, see the docstring for
+    observedFromICRS in AstrometryUtils.py
+    """
+    raOut, decOut = _raDecFromPixelCoordinates(xPixList, yPixList, chipNameList,
+                                               camera=camera, obs_metadata=obs_metadata,
+                                               epoch=epoch, includeDistortion=includeDistortion)
+
+    return numpy.degrees(raOut), numpy.degrees(decOut)
+
+
+def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
+                          obs_metadata=None, epoch=None, includeDistortion=True):
     """
     Convert pixel coordinates into observed RA, Dec
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -191,7 +191,8 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] a numpy array of pixel coordinates
+    @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+    and the second row is the y pixel coordinate
     """
 
     return _pixelCoordsFromRaDec(numpy.radians(ra), numpy.radians(dec),
@@ -229,7 +230,8 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] a numpy array of pixel coordinates
+    @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+    and the second row is the y pixel coordinate
     """
 
     if epoch is None:
@@ -286,7 +288,8 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] a numpy array of pixel coordinates
+    @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+    and the second row is the y pixel coordinate
     """
 
     if includeDistortion:
@@ -349,9 +352,8 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] xPupilList is a numpy array of the x pupil coordinate (in radians)
-
-    @param [out] yPupilList is a numpyarray of the y pupil coordinate (in radians)
+    @param [out] a 2-D numpy array in which the first row is the x pupil coordinate
+    and the second row is the y pupil coordinate (both in radians)
     """
 
     if camera is None:
@@ -415,18 +417,17 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] ra is a numpy array of observed RA in degrees
-
-    @param [out] dec is a numpy array of observed Dec in degrees
+    @param [out] a 2-D numpy array in which the first row is the RA coordinate
+    and the second row is the Dec coordinate (both in degrees)
 
     Note: to see what is mean by 'observed' ra/dec, see the docstring for
     observedFromICRS in AstrometryUtils.py
     """
-    raOut, decOut = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
-                                          camera=camera, obs_metadata=obs_metadata,
-                                          epoch=epoch, includeDistortion=includeDistortion)
+    output = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                   camera=camera, obs_metadata=obs_metadata,
+                                   epoch=epoch, includeDistortion=includeDistortion)
 
-    return numpy.degrees(raOut), numpy.degrees(decOut)
+    return numpy.degrees(output)
 
 
 def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
@@ -453,9 +454,8 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] ra is a numpy array of observed RA in radians
-
-    @param [out] dec is a numpy array of observed Dec in radians
+    @param [out] a 2-D numpy array in which the first row is the RA coordinate
+    and the second row is the Dec coordinate (both in radians)
 
     Note: to see what is mean by 'observed' ra/dec, see the docstring for
     observedFromICRS in AstrometryUtils.py
@@ -496,7 +496,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     raOut, decOut = _raDecFromPupilCoords(xPupilList, yPupilList,
                                   obs_metadata=obs_metadata, epoch=epoch)
 
-    return raOut, decOut
+    return numpy.array([raOut, decOut])
 
 
 def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None):
@@ -515,7 +515,9 @@ def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=Non
 
     @param [in] camera is an afw.cameraGeom camera object
 
-    @param [out] the x and y coordinates on the focalplane in millimeters
+    @param [out] a 2-D numpy array in which the first row is the x
+    focal plane coordinate and the second row is the y focal plane
+    coordinate (both in millimeters)
     """
 
     return _focalPlaneCoordsFromRaDec(numpy.radians(ra), numpy.radians(dec),
@@ -539,7 +541,9 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=No
 
     @param [in] camera is an afw.cameraGeom camera object
 
-    @param [out] the x and y coordinates on the focalplane in millimeters
+    @param [out] a 2-D numpy array in which the first row is the x
+    focal plane coordinate and the second row is the y focal plane
+    coordinate (both in millimeters)
     """
 
     if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
@@ -583,7 +587,9 @@ def focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=None):
 
     @param [in] camera is an afw.cameraGeom camera object
 
-    @param [out] the x and y coordinates on the focalplane in millimeters
+    @param [out] a 2-D numpy array in which the first row is the x
+    focal plane coordinate and the second row is the y focal plane
+    coordinate (both in millimeters)
     """
 
     if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
@@ -604,4 +610,5 @@ def focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=None):
         fpPoint = camera.transform(cp, FOCAL_PLANE)
         xPix.append(fpPoint.getPoint().getX())
         yPix.append(fpPoint.getPoint().getY())
-    return xPix, yPix
+
+    return numpy.array([xPix, yPix])

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -199,6 +199,7 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
                                  includeDistortion=includeDistortion,
                                  obs_metadata=obs_metadata, epoch=epoch)
 
+
 def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
                           chipNames=None, camera=None, includeDistortion=True):
     """

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -421,9 +421,9 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     Note: to see what is mean by 'observed' ra/dec, see the docstring for
     observedFromICRS in AstrometryUtils.py
     """
-    raOut, decOut = _raDecFromPixelCoordinates(xPixList, yPixList, chipNameList,
-                                               camera=camera, obs_metadata=obs_metadata,
-                                               epoch=epoch, includeDistortion=includeDistortion)
+    raOut, decOut = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                          camera=camera, obs_metadata=obs_metadata,
+                                          epoch=epoch, includeDistortion=includeDistortion)
 
     return numpy.degrees(raOut), numpy.degrees(decOut)
 
@@ -460,9 +460,37 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     observedFromICRS in AstrometryUtils.py
     """
 
-    xPupilList, yPupilList = pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList,
-                                     camera=camera, obs_metadata=obs_metadata, epoch=epoch,
-                                     includeDistortion=includeDistortion)
+    if camera is None:
+        raise RuntimeError("You cannot call raDecFromPixelCoords without specifying a camera")
+
+    if epoch is None:
+        raise RuntimeError("You cannot call raDecFromPixelCoords without specifying an epoch")
+
+    if obs_metadata is None:
+        raise RuntimeError("You cannot call raDecFromPixelCoords without an ObservationMetaData")
+
+    if obs_metadata.mjd is None:
+        raise RuntimeError("The ObservationMetaData in raDecFromPixelCoords must have an mjd")
+
+    if obs_metadata.rotSkyPos is None:
+        raise RuntimeError("The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
+
+    if not isinstance(xPixList, numpy.ndarray) or not isinstance(yPixList, numpy.ndarray):
+        raise RuntimeError("You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
+
+    if len(xPixList)!=len(yPixList):
+        raise RuntimeError("You passed %d xPix coordinates but %d yPix coordinates " \
+                           % (len(xPixList), len(yPixList)) \
+                           +"to raDecFromPixelCoords")
+
+    if len(xPixList)!=len(chipNameList):
+        raise RuntimeError("You passed %d pixel coordinate pairs but %d chip names " \
+                          % (len(xPixList), len(chipNameList)) \
+                          +"to raDecFromPixelCoords")
+
+
+    xPupilList, yPupilList = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList,
+                                                        camera=camera, includeDistortion=includeDistortion)
 
     raOut, decOut = _raDecFromPupilCoords(xPupilList, yPupilList,
                                   obs_metadata=obs_metadata, epoch=epoch)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -83,11 +83,23 @@ def _findChipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     """
 
     if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
-        raise RuntimeError("You need to pass numpy arrays of RA and Dec to findChipnameFromRaDec")
+        raise RuntimeError("You need to pass numpy arrays of RA and Dec to findChipName")
 
     if len(ra) != len(dec):
         raise RuntimeError("You passed %d RAs and %d Decs " % (len(ra), len(dec)) +
-                           "to findChipNameFromRaDec.")
+                           "to findChipName.")
+
+    if epoch is None:
+        raise RuntimeError("You need to pass an epoch into findChipName")
+
+    if obs_metadata is None:
+        raise RuntimeError("You need to pass an ObservationMetaData into findChipName")
+
+    if obs_metadata.mjd is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into findChipName")
+
+    if obs_metadata.rotSkyPos is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into findChipName")
 
     xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
     return findChipNameFromPupilCoords(xp, yp, camera=camera, allow_multiple_chips=allow_multiple_chips)
@@ -120,10 +132,10 @@ def findChipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chip
 
     if len(xPupil) != len(yPupil):
         raise RuntimeError("You passed %d xPupils and %d yPupils " % (len(xPupil), len(yPupil)) +
-                           "to findChipNameFromPupilCoords.")
+                           "to findChipName.")
 
     if camera is None:
-        raise RuntimeError("No camera defined.  Cannot rin findChipNameFromPupilCoords.")
+        raise RuntimeError("No camera defined.  Cannot rin findChipName.")
 
     chipNames = []
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -488,11 +488,20 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=No
 
     if epoch is None:
         raise RuntimeError("You have to specify an epoch to run " + \
-                            "focalPlaneCoordsFromRaDec on these inputs")
+                            "focalPlaneCoordsFromRaDec")
 
     if obs_metadata is None:
         raise RuntimeError("You have to specify an ObservationMetaData to run " + \
-                               "focalPlaneCoordsFromRaDec on these inputs")
+                               "focalPlaneCoordsFromRaDec")
+
+
+    if obs_metadata.mjd is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with an " \
+                           + "mjd into focalPlaneCoordsFromRaDec")
+
+    if obs_metadata.rotSkyPos is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with a " \
+                           + "rotSkyPos into focalPlaneCoordsFromRaDec")
 
 
     xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata,

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -7,7 +7,8 @@ from lsst.sims.coordUtils.AstrometryUtils import _pupilCoordsFromRaDec, _raDecFr
 __all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
            "pixelCoordsFromPupilCoords", "pixelCoordsFromRaDec", "_pixelCoordsFromRaDec",
            "focalPlaneCoordsFromPupilCoords", "focalPlaneCoordsFromRaDec", "_focalPlaneCoordsFromRaDec",
-           "_raDecFromPixelCoordinates", "pupilCoordinatesFromPixelCoordinates"]
+           "pupilCoordsFromPixelCoords",
+           "_raDecFromPixelCoordinates"]
 
 
 def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
@@ -326,8 +327,8 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     return numpy.array([xPix, yPix])
 
 
-def pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
-                                         obs_metadata=None, epoch=None, includeDistortion=True):
+def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
+                               includeDistortion=True):
 
     """
     Convert pixel coordinates into pupil coordinates
@@ -341,10 +342,6 @@ def pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList, camer
 
     @param [in] camera is an afw.CameraGeom.camera object defining the camera
 
-    @param [in] obs_metadata is an ObservationMetaData defining the pointing
-
-    @param [in] epoch is the mean epoch in years of the celestial coordinate system
-
     @param [in] includeDistortion is a boolean.  If True (default), then this method will
     expect the true pixel coordinates with optical distortion included.  If False, this
     method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
@@ -355,6 +352,9 @@ def pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList, camer
 
     @param [out] yPupilList is a numpyarray of the y pupil coordinate (in radians)
     """
+
+    if camera is None:
+        raise RuntimeError("You cannot call pupilCoordsFromPixelCoords without specifying a camera")
 
     if includeDistortion:
         pixelType = PIXELS

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -2,7 +2,8 @@ import numpy
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import SCIENCE
-from lsst.sims.coordUtils.AstrometryUtils import _calculatePupilCoordinates, _raDecFromPupilCoordinates
+from lsst.sims.coordUtils.AstrometryUtils import _pupilCoordsFromRaDec, _raDecFromPupilCoords, \
+                                                 pupilCoordsFromRaDec
 
 __all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
            "calculatePixelCoordinates", "calculateFocalPlaneCoordinates",

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -365,11 +365,7 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     pupilSystemDict = {}
     detectorDict = {}
     for name in chipNameList:
-        if name not in pixelSystemDict:
-            if name is None:
-                pixelSystemDict[name] = None
-                pupilSystemDict[name] = None
-            else:
+        if name not in pixelSystemDict and name is not None and name!='None':
                 pixelSystemDict[name] = camera[name].makeCameraSys(pixelType)
                 pupilSystemDict[name] = camera[name].makeCameraSys(PUPIL)
 
@@ -379,7 +375,7 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     yPupilList = []
 
     for xPix, yPix, chipName in zip(xPixList, yPixList, chipNameList):
-        if chipName is None:
+        if chipName is None or chipName=='None':
             xPupilList.append(numpy.NaN)
             yPupilList.append(numpy.NaN)
         else:

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -245,7 +245,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
                            + "pixelCoordsFromRaDec")
 
     if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
-        raise RuntimeError("You need to pass numpy arrays of ra and dec to pixelCoordsFromRaDec")
+        raise RuntimeError("You need to pass numpy arrays of RA and Dec to pixelCoordsFromRaDec")
 
     if len(ra) != len(dec):
         raise RuntimeError("You passed %d RA and %d Dec coordinates " % (len(ra), len(dec)) +
@@ -253,7 +253,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
 
     if chipNames is not None:
         if len(ra) != len(chipNames):
-            raise RuntimeError("You passed %d points but only %d chipNames to pixelCoordsFromRaDec" %
+            raise RuntimeError("You passed %d points but %d chipNames to pixelCoordsFromRaDec" %
                                (len(ra), len(chipNames)))
 
     xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
@@ -293,7 +293,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
         pixelType = TAN_PIXELS
 
     if not camera:
-        raise RuntimeError("You need a camera to calculate pixel coordinates")
+        raise RuntimeError("Camera not specified.  Cannot calculate pixel coordinates.")
 
     if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
         raise RuntimeError("You need to pass numpy arrays of xPupil and yPupil to pixelCoordsFromPupilCoords")
@@ -304,7 +304,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
 
     if chipNames is not None:
         if len(xPupil) != len(chipNames):
-            raise RuntimeError("You passed %d points but only %d chipNames to pixelCoordsFromPupilCoords" %
+            raise RuntimeError("You passed %d points but %d chipNames to pixelCoordsFromPupilCoords" %
                                (len(xPupil), len(chipNames)))
 
     if chipNames is None:

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -2,10 +2,10 @@ import numpy
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import SCIENCE
-from lsst.sims.coordUtils.AstrometryUtils import calculatePupilCoordinates, raDecFromPupilCoordinates
+from lsst.sims.coordUtils.AstrometryUtils import _calculatePupilCoordinates, _raDecFromPupilCoordinates
 
 __all__ = ["findChipName", "calculatePixelCoordinates", "calculateFocalPlaneCoordinates",
-           "raDecFromPixelCoordinates", "pupilCoordinatesFromPixelCoordinates"]
+           "_raDecFromPixelCoordinates", "pupilCoordinatesFromPixelCoordinates"]
 
 def findChipName(xPupil=None, yPupil=None, ra=None, dec=None,
                  obs_metadata=None, epoch=None, camera=None,
@@ -15,9 +15,9 @@ def findChipName(xPupil=None, yPupil=None, ra=None, dec=None,
     either (xPupil, yPupil) or (ra, dec).  Note: this method does not return
     the name of guide, focus, or wavefront detectors.
 
-    @param [in] xPupil a numpy array of x pupil coordinates
+    @param [in] xPupil a numpy array of x pupil coordinates in radians
 
-    @param [in] yPupil a numpy array of y pupil coordinates
+    @param [in] yPupil a numpy array of y pupil coordinates in radians
 
     @param [in] ra in radians (optional; should not specify both ra/dec and pupil coordinates)
 
@@ -80,7 +80,7 @@ def findChipName(xPupil=None, yPupil=None, ra=None, dec=None,
             raise RuntimeError("You have to specifay an ObservationMetaData to run " + \
                                "findChipName on these inputs")
 
-        xPupil, yPupil = calculatePupilCoordinates(ra, dec, epoch=epoch, obs_metadata=obs_metadata)
+        xPupil, yPupil = _calculatePupilCoordinates(ra, dec, epoch=epoch, obs_metadata=obs_metadata)
 
     if camera is None:
         raise RuntimeError("No camera defined.  Cannot rin findChipName.")
@@ -114,9 +114,9 @@ def calculatePixelCoordinates(xPupil=None, yPupil=None, ra=None, dec=None, chipN
     """
     Get the pixel positions (or nan if not on a chip) for all objects in the catalog
 
-    @param [in] xPupil a numpy array containing x pupil coordinates
+    @param [in] xPupil a numpy array containing x pupil coordinates in radians
 
-    @param [in] yPupil a numpy array containing y pupil coordinates
+    @param [in] yPupil a numpy array containing y pupil coordinates in radians
 
     @param [in] ra one could alternatively provide a numpy array of ra and...
 
@@ -202,9 +202,9 @@ def calculatePixelCoordinates(xPupil=None, yPupil=None, ra=None, dec=None, chipN
             raise RuntimeError("You need to specify an ObservationMetaDAta to run " + \
                                    "calculatePixelCoordinates on these inputs")
 
-        xPupil, yPupil = calculatePupilCoordinates(ra, dec,
-                                                   obs_metadata=obs_metadata,
-                                                   epoch=epoch)
+        xPupil, yPupil = _calculatePupilCoordinates(ra, dec,
+                                                    obs_metadata=obs_metadata,
+                                                    epoch=epoch)
 
     if chipNames is None:
         chipNames = findChipName(xPupil = xPupil, yPupil = yPupil, camera=camera)
@@ -293,7 +293,7 @@ def pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList, camer
     return xPupilList, yPupilList
 
 
-def raDecFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
+def _raDecFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
                               obs_metadata=None, epoch=None, includeDistortion=True):
     """
     Convert pixel coordinates into observed RA, Dec
@@ -317,9 +317,9 @@ def raDecFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
     estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
     details.
 
-    @param [out] ra is a numpy array of observed RA
+    @param [out] ra is a numpy array of observed RA in radians
 
-    @param [out] dec is a numpy array of observed Dec
+    @param [out] dec is a numpy array of observed Dec in radians
 
     Note: to see what is mean by 'observed' ra/dec, see the docstring for
     observedFromICRS in AstrometryUtils.py
@@ -329,8 +329,8 @@ def raDecFromPixelCoordinates(xPixList, yPixList, chipNameList, camera=None,
                                      camera=camera, obs_metadata=obs_metadata, epoch=epoch,
                                      includeDistortion=includeDistortion)
 
-    raOut, decOut = raDecFromPupilCoordinates(xPupilList, yPupilList,
-                                 obs_metadata=obs_metadata, epoch=epoch)
+    raOut, decOut = _raDecFromPupilCoordinates(xPupilList, yPupilList,
+                                  obs_metadata=obs_metadata, epoch=epoch)
 
     return raOut, decOut
 
@@ -395,8 +395,8 @@ def calculateFocalPlaneCoordinates(xPupil=None, yPupil=None, ra=None, dec=None,
             raise RuntimeError("You have to specify an ObservationMetaData to run " + \
                                    "calculateFocalPlaneCoordinates on these inputs")
 
-        xPupil, yPupil = calculatePupilCoordinates(ra ,dec,
-                                                   obs_metadata=obs_metadata, epoch=epoch)
+        xPupil, yPupil = _calculatePupilCoordinates(ra ,dec,
+                                                    obs_metadata=obs_metadata, epoch=epoch)
 
     xPix = []
     yPix = []

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -136,7 +136,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                            "to chipName.")
 
     if camera is None:
-        raise RuntimeError("No camera defined.  Cannot rin chipName.")
+        raise RuntimeError("No camera defined.  Cannot run chipName.")
 
     chipNames = []
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -495,7 +495,7 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=No
                                "focalPlaneCoordsFromRaDec on these inputs")
 
 
-    xPupil, yPupil = _pupilCoordinatesFromRaDec(ra, dec, obs_metadata=obs_metadata,
+    xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata,
                                                 epoch=epoch)
 
     return focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=camera)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -4,12 +4,12 @@ from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import SCIENCE
 from lsst.sims.coordUtils.AstrometryUtils import _calculatePupilCoordinates, _raDecFromPupilCoordinates
 
-__all__ = ["findChipNameFromPupilCoords", "findChipNameFromRaDec", "_findChipNameFromRaDec",
+__all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
            "calculatePixelCoordinates", "calculateFocalPlaneCoordinates",
            "_raDecFromPixelCoordinates", "pupilCoordinatesFromPixelCoordinates"]
 
 
-def findChipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
+def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
                            allow_multiple_chips=False):
     """
     Return the names of science detectors that see the object specified by
@@ -43,12 +43,12 @@ def findChipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     @param [out] a numpy array of chip names (science detectors only)
     """
 
-    return _findChipNameFromRaDec(numpy.radians(ra), numpy.radians(dec),
+    return _chipNameFromRaDec(numpy.radians(ra), numpy.radians(dec),
                                   obs_metadata=obs_metadata, epoch=epoch,
                                   camera=camera, allow_multiple_chips=allow_multiple_chips)
 
 
-def _findChipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
+def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
                            allow_multiple_chips=False):
     """
     Return the names of science detectors that see the object specified by
@@ -83,29 +83,29 @@ def _findChipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     """
 
     if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
-        raise RuntimeError("You need to pass numpy arrays of RA and Dec to findChipName")
+        raise RuntimeError("You need to pass numpy arrays of RA and Dec to chipName")
 
     if len(ra) != len(dec):
         raise RuntimeError("You passed %d RAs and %d Decs " % (len(ra), len(dec)) +
-                           "to findChipName.")
+                           "to chipName.")
 
     if epoch is None:
-        raise RuntimeError("You need to pass an epoch into findChipName")
+        raise RuntimeError("You need to pass an epoch into chipName")
 
     if obs_metadata is None:
-        raise RuntimeError("You need to pass an ObservationMetaData into findChipName")
+        raise RuntimeError("You need to pass an ObservationMetaData into chipName")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into findChipName")
+        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into chipName")
 
     if obs_metadata.rotSkyPos is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into findChipName")
+        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into chipName")
 
     xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
-    return findChipNameFromPupilCoords(xp, yp, camera=camera, allow_multiple_chips=allow_multiple_chips)
+    return chipNameFromPupilCoords(xp, yp, camera=camera, allow_multiple_chips=allow_multiple_chips)
 
 
-def findChipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=False):
+def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=False):
     """
     Return the names of science detectors that see the object specified by
     either (xPupil, yPupil).  Note: this method does not return
@@ -128,14 +128,14 @@ def findChipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chip
     """
 
     if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
-        raise RuntimeError("You need to pass numpy arrays of xPupil and yPupil to findChipnameFromPupilCoords")
+        raise RuntimeError("You need to pass numpy arrays of xPupil and yPupil to chipNameFromPupilCoords")
 
     if len(xPupil) != len(yPupil):
         raise RuntimeError("You passed %d xPupils and %d yPupils " % (len(xPupil), len(yPupil)) +
-                           "to findChipName.")
+                           "to chipName.")
 
     if camera is None:
-        raise RuntimeError("No camera defined.  Cannot rin findChipName.")
+        raise RuntimeError("No camera defined.  Cannot rin chipName.")
 
     chipNames = []
 
@@ -174,9 +174,9 @@ def calculatePixelCoordinates(xPupil=None, yPupil=None, ra=None, dec=None, chipN
 
     @param [in] ...dec (both in radians)
 
-    @param [in] chipNames a numpy array of chipNames.  If it is None, this method will call findChipName
+    @param [in] chipNames a numpy array of chipNames.  If it is None, this method will call chipName
     to find the array.  The option exists for the user to specify chipNames, just in case the user
-    has already called findChipName for some reason.
+    has already called chipName for some reason.
 
     @param [in] obs_metadata is an ObservationMetaData object describing the telescope pointing
     (only if specifying RA and Dec rather than pupil coordinates)
@@ -185,7 +185,7 @@ def calculatePixelCoordinates(xPupil=None, yPupil=None, ra=None, dec=None, chipN
     (in years; only if specifying RA and Dec rather than pupil coordinates)
 
     @param [in] camera is an afwCameraGeom object specifying the attributes of the camera.
-    This is an optional argument to be passed to findChipName.
+    This is an optional argument to be passed to chipName.
 
     @param [in] includeDistortion is a boolean.  If True (default), then this method will
     return the true pixel coordinates with optical distortion included.  If False, this
@@ -259,7 +259,7 @@ def calculatePixelCoordinates(xPupil=None, yPupil=None, ra=None, dec=None, chipN
                                                     epoch=epoch)
 
     if chipNames is None:
-        chipNames = findChipName(xPupil = xPupil, yPupil = yPupil, camera=camera)
+        chipNames = chipName(xPupil = xPupil, yPupil = yPupil, camera=camera)
 
     xPix = []
     yPix = []

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -437,20 +437,20 @@ class astrometryUnitTest(unittest.TestCase):
 
         output=_observedFromAppGeo(ra,dec,altAzHr=True, wavelength=wv, obs_metadata=obs_metadata)
 
-        self.assertAlmostEqual(output[0][0],2.547475965605183745e+00,6)
-        self.assertAlmostEqual(output[1][0],5.187045152602967057e-01,6)
-        self.assertAlmostEqual(output[2][0],1.168920017932007643e-01,6)
-        self.assertAlmostEqual(output[3][0],8.745379535264000692e-01,6)
+        self.assertAlmostEqual(output[0][0][0],2.547475965605183745e+00,6)
+        self.assertAlmostEqual(output[0][1][0],5.187045152602967057e-01,6)
+        self.assertAlmostEqual(output[1][0][0],1.168920017932007643e-01,6)
+        self.assertAlmostEqual(output[1][1][0],8.745379535264000692e-01,6)
 
-        self.assertAlmostEqual(output[0][1],4.349858626308809040e-01,6)
-        self.assertAlmostEqual(output[1][1],-5.191213875880701378e-01,6)
-        self.assertAlmostEqual(output[2][1],6.766119585479937193e-01,6)
-        self.assertAlmostEqual(output[3][1],4.433969998336554141e+00,6)
+        self.assertAlmostEqual(output[0][0][1],4.349858626308809040e-01,6)
+        self.assertAlmostEqual(output[0][1][1],-5.191213875880701378e-01,6)
+        self.assertAlmostEqual(output[1][0][1],6.766119585479937193e-01,6)
+        self.assertAlmostEqual(output[1][1][1],4.433969998336554141e+00,6)
 
-        self.assertAlmostEqual(output[0][2],7.743528611421227614e-01,6)
-        self.assertAlmostEqual(output[1][2],2.755070101670137328e-01,6)
-        self.assertAlmostEqual(output[2][2],5.275840601437552513e-01,6)
-        self.assertAlmostEqual(output[3][2],5.479759580847959555e+00,6)
+        self.assertAlmostEqual(output[0][0][2],7.743528611421227614e-01,6)
+        self.assertAlmostEqual(output[0][1][2],2.755070101670137328e-01,6)
+        self.assertAlmostEqual(output[1][0][2],5.275840601437552513e-01,6)
+        self.assertAlmostEqual(output[1][1][2],5.479759580847959555e+00,6)
 
         output=_observedFromAppGeo(ra,dec,includeRefraction=False,
                                   wavelength=wv, obs_metadata=obs_metadata)
@@ -467,20 +467,20 @@ class astrometryUnitTest(unittest.TestCase):
         output=_observedFromAppGeo(ra,dec,includeRefraction=False,
                                   altAzHr=True, wavelength=wv, obs_metadata=obs_metadata)
 
-        self.assertAlmostEqual(output[0][0],2.549091783674975353e+00,6)
-        self.assertAlmostEqual(output[1][0],5.198746844679964507e-01,6)
-        self.assertAlmostEqual(output[2][0],1.150652107618796299e-01,6)
-        self.assertAlmostEqual(output[3][0],8.745379535264000692e-01,6)
+        self.assertAlmostEqual(output[0][0][0],2.549091783674975353e+00,6)
+        self.assertAlmostEqual(output[0][1][0],5.198746844679964507e-01,6)
+        self.assertAlmostEqual(output[1][0][0],1.150652107618796299e-01,6)
+        self.assertAlmostEqual(output[1][1][0],8.745379535264000692e-01,6)
 
-        self.assertAlmostEqual(output[0][1],4.346695674418772359e-01,6)
-        self.assertAlmostEqual(output[1][1],-5.190436610150490626e-01,6)
-        self.assertAlmostEqual(output[2][1],6.763265401447272618e-01,6)
-        self.assertAlmostEqual(output[3][1],4.433969998336554141e+00,6)
+        self.assertAlmostEqual(output[0][0][1],4.346695674418772359e-01,6)
+        self.assertAlmostEqual(output[0][1][1],-5.190436610150490626e-01,6)
+        self.assertAlmostEqual(output[1][0][1],6.763265401447272618e-01,6)
+        self.assertAlmostEqual(output[1][1][1],4.433969998336554141e+00,6)
 
-        self.assertAlmostEqual(output[0][2],7.740875471580924705e-01,6)
-        self.assertAlmostEqual(output[1][2],2.758055401087299296e-01,6)
-        self.assertAlmostEqual(output[2][2],5.271912536356709866e-01,6)
-        self.assertAlmostEqual(output[3][2],5.479759580847959555e+00,6)
+        self.assertAlmostEqual(output[0][0][2],7.740875471580924705e-01,6)
+        self.assertAlmostEqual(output[0][1][2],2.758055401087299296e-01,6)
+        self.assertAlmostEqual(output[1][0][2],5.271912536356709866e-01,6)
+        self.assertAlmostEqual(output[1][1][2],5.479759580847959555e+00,6)
 
     def test_observedFromAppGeo_NoRefraction(self):
 
@@ -503,14 +503,14 @@ class astrometryUnitTest(unittest.TestCase):
         output=_observedFromAppGeo(ra,dec,altAzHr=True,
                                   includeRefraction=False, obs_metadata=obs_metadata)
 
-        self.assertAlmostEqual(output[0][0],2.549091783674975353e+00,6)
-        self.assertAlmostEqual(output[1][0],5.198746844679964507e-01,6)
-        self.assertAlmostEqual(output[0][1],4.346695674418772359e-01,6)
-        self.assertAlmostEqual(output[1][1],-5.190436610150490626e-01,6)
-        self.assertAlmostEqual(output[0][2],7.740875471580924705e-01,6)
-        self.assertAlmostEqual(output[1][2],2.758055401087299296e-01,6)
-        self.assertAlmostEqual(output[2][2],5.271914342095551653e-01,6)
-        self.assertAlmostEqual(output[3][2],5.479759402150099490e+00,6)
+        self.assertAlmostEqual(output[0][0][0],2.549091783674975353e+00,6)
+        self.assertAlmostEqual(output[0][1][0],5.198746844679964507e-01,6)
+        self.assertAlmostEqual(output[0][0][1],4.346695674418772359e-01,6)
+        self.assertAlmostEqual(output[0][1][1],-5.190436610150490626e-01,6)
+        self.assertAlmostEqual(output[0][0][2],7.740875471580924705e-01,6)
+        self.assertAlmostEqual(output[0][1][2],2.758055401087299296e-01,6)
+        self.assertAlmostEqual(output[1][0][2],5.271914342095551653e-01,6)
+        self.assertAlmostEqual(output[1][1][2],5.479759402150099490e+00,6)
 
     def testRefractionCoefficients(self):
         output=refractionCoefficients(wavelength=5000.0, site=self.obs_metadata.site)

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -26,7 +26,7 @@ import lsst.utils.tests as utilsTests
 from lsst.utils import getPackageDir
 
 from lsst.sims.utils import ObservationMetaData
-from lsst.sims.utils import getRotTelPos, raDecFromAltAz, calcObsDefaults, \
+from lsst.sims.utils import _getRotTelPos, _raDecFromAltAz, calcObsDefaults, \
                             radiansFromArcsec, arcsecFromRadians, Site
 
 from lsst.sims.coordUtils import _applyPrecession, _applyProperMotion
@@ -42,8 +42,8 @@ def makeObservationMetaData():
     band = 'r'
     testSite = Site(latitude=0.5, longitude=1.1, height=3000, meanTemperature=260.0,
                     meanPressure=725.0, lapseRate=0.005)
-    centerRA, centerDec = raDecFromAltAz(alt,az,testSite.longitude,testSite.latitude,mjd)
-    rotTel = getRotTelPos(centerRA, centerDec, testSite.longitude, testSite.latitude, mjd, 0.0)
+    centerRA, centerDec = _raDecFromAltAz(alt,az,testSite.longitude,testSite.latitude,mjd)
+    rotTel = _getRotTelPos(centerRA, centerDec, testSite.longitude, testSite.latitude, mjd, 0.0)
 
     obsDict = calcObsDefaults(centerRA, centerDec, alt, az, rotTel, mjd, band,
                  testSite.longitude, testSite.latitude)

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -29,9 +29,9 @@ from lsst.sims.utils import ObservationMetaData
 from lsst.sims.utils import getRotTelPos, raDecFromAltAz, calcObsDefaults, \
                             radiansFromArcsec, arcsecFromRadians, Site
 
-from lsst.sims.coordUtils import applyPrecession, applyProperMotion
-from lsst.sims.coordUtils import appGeoFromICRS, observedFromAppGeo
-from lsst.sims.coordUtils import observedFromICRS
+from lsst.sims.coordUtils import _applyPrecession, _applyProperMotion
+from lsst.sims.coordUtils import _appGeoFromICRS, _observedFromAppGeo
+from lsst.sims.coordUtils import _observedFromICRS
 from lsst.sims.coordUtils import refractionCoefficients, applyRefraction
 
 def makeObservationMetaData():
@@ -142,18 +142,18 @@ class astrometryUnitTest(unittest.TestCase):
         zd = numpy.array([0.1, 0.2])
         rzd = applyRefraction(zd, x, y)
 
-        ##########test applyPrecession
+        ##########test _applyPrecession
         #test without mjd
-        self.assertRaises(RuntimeError, applyPrecession, ra, dec)
+        self.assertRaises(RuntimeError, _applyPrecession, ra, dec)
 
         #test mismatches
-        self.assertRaises(RuntimeError, applyPrecession, raShort, dec, mjd=52000.0)
-        self.assertRaises(RuntimeError, applyPrecession, ra, decShort, mjd=52000.0)
+        self.assertRaises(RuntimeError, _applyPrecession, raShort, dec, mjd=52000.0)
+        self.assertRaises(RuntimeError, _applyPrecession, ra, decShort, mjd=52000.0)
 
         #test that it runs
-        applyPrecession(ra, dec, mjd=52000.0)
+        _applyPrecession(ra, dec, mjd=52000.0)
 
-        ##########test applyProperMotion
+        ##########test _applyProperMotion
         raList = list(ra)
         decList = list(dec)
         pm_raList = list(pm_ra)
@@ -167,81 +167,81 @@ class astrometryUnitTest(unittest.TestCase):
         v_radShort = numpy.array([v_rad[0]])
 
         #test without mjd
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_dec, parallax, v_rad)
 
         #test passing lists
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           raList, dec, pm_ra, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, decList, pm_ra, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_raList, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_decList, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_dec, parallaxList, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_dec, parallax, v_radList,
                           mjd=52000.0)
 
         #test mismatches
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           raShort, dec, pm_ra, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, decShort, pm_ra, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_raShort, pm_dec, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_decShort, parallax, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_dec, parallaxShort, v_rad,
                           mjd=52000.0)
-        self.assertRaises(RuntimeError, applyProperMotion,
+        self.assertRaises(RuntimeError, _applyProperMotion,
                           ra, dec, pm_ra, pm_dec, parallax, v_radShort,
                           mjd=52000.0)
 
         #test that it actually runs
-        applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, mjd=52000.0)
-        applyProperMotion(ra[0], dec[0], pm_ra[0], pm_dec[0], parallax[0], v_rad[0],
+        _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, mjd=52000.0)
+        _applyProperMotion(ra[0], dec[0], pm_ra[0], pm_dec[0], parallax[0], v_rad[0],
                           mjd=52000.0)
 
-        ##########test appGeoFromICRS
+        ##########test _appGeoFromICRS
         #test without mjd
-        self.assertRaises(RuntimeError, appGeoFromICRS, ra, dec)
+        self.assertRaises(RuntimeError, _appGeoFromICRS, ra, dec)
 
         #test with mismatched ra, dec
-        self.assertRaises(RuntimeError, appGeoFromICRS, ra, decShort, mjd=52000.0)
-        self.assertRaises(RuntimeError, appGeoFromICRS, raShort, dec, mjd=52000.0)
+        self.assertRaises(RuntimeError, _appGeoFromICRS, ra, decShort, mjd=52000.0)
+        self.assertRaises(RuntimeError, _appGeoFromICRS, raShort, dec, mjd=52000.0)
 
         #test that it actually urns
-        test=appGeoFromICRS(ra, dec, mjd=obs_metadata.mjd)
+        test=_appGeoFromICRS(ra, dec, mjd=obs_metadata.mjd)
 
-        ##########test observedFromAppGeo
+        ##########test _observedFromAppGeo
         #test without obs_metadata
-        self.assertRaises(RuntimeError, observedFromAppGeo, ra, dec)
+        self.assertRaises(RuntimeError, _observedFromAppGeo, ra, dec)
 
         #test without site
         dummy=ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                   unrefractedDec=obs_metadata.unrefractedDec,
                                   mjd=obs_metadata.mjd,
                                   site=None)
-        self.assertRaises(RuntimeError, observedFromAppGeo, ra, dec, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromAppGeo, ra, dec, obs_metadata=dummy)
 
         #test without mjd
         dummy=ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                   unrefractedDec=obs_metadata.unrefractedDec,
                                   site=Site())
-        self.assertRaises(RuntimeError, observedFromAppGeo, ra, dec, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromAppGeo, ra, dec, obs_metadata=dummy)
 
         #test mismatches
         dummy=ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
@@ -249,24 +249,24 @@ class astrometryUnitTest(unittest.TestCase):
                                   mjd=obs_metadata.mjd,
                                   site=Site())
 
-        self.assertRaises(RuntimeError, observedFromAppGeo, ra, decShort, obs_metadata=dummy)
-        self.assertRaises(RuntimeError, observedFromAppGeo, raShort, dec, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromAppGeo, ra, decShort, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromAppGeo, raShort, dec, obs_metadata=dummy)
 
         #test that it actually runs
-        test = observedFromAppGeo(ra, dec, obs_metadata=dummy)
+        test = _observedFromAppGeo(ra, dec, obs_metadata=dummy)
 
-        ##########test observedFromICRS
+        ##########test _observedFromICRS
         #test without epoch
-        self.assertRaises(RuntimeError, observedFromICRS, ra, dec, obs_metadata=obs_metadata)
+        self.assertRaises(RuntimeError, _observedFromICRS, ra, dec, obs_metadata=obs_metadata)
 
         #test without obs_metadata
-        self.assertRaises(RuntimeError, observedFromICRS, ra, dec, epoch=2000.0)
+        self.assertRaises(RuntimeError, _observedFromICRS, ra, dec, epoch=2000.0)
 
         #test without mjd
         dummy=ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                   unrefractedDec=obs_metadata.unrefractedDec,
                                   site=obs_metadata.site)
-        self.assertRaises(RuntimeError, observedFromICRS, ra, dec, epoch=2000.0, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromICRS, ra, dec, epoch=2000.0, obs_metadata=dummy)
 
         #test that it actually runs
         dummy=ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
@@ -275,15 +275,15 @@ class astrometryUnitTest(unittest.TestCase):
                                   mjd=obs_metadata.mjd)
 
         #test mismatches
-        self.assertRaises(RuntimeError, observedFromICRS, ra, decShort, epoch=2000.0, obs_metadata=dummy)
-        self.assertRaises(RuntimeError, observedFromICRS, raShort, dec, epoch=2000.0, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromICRS, ra, decShort, epoch=2000.0, obs_metadata=dummy)
+        self.assertRaises(RuntimeError, _observedFromICRS, raShort, dec, epoch=2000.0, obs_metadata=dummy)
 
         #test that it actually runs
-        test = observedFromICRS(ra, dec, obs_metadata=dummy, epoch=2000.0)
+        test = _observedFromICRS(ra, dec, obs_metadata=dummy, epoch=2000.0)
 
 
 
-    def testApplyPrecession(self):
+    def test_applyPrecession(self):
 
         ra=numpy.zeros((3),dtype=float)
         dec=numpy.zeros((3),dtype=float)
@@ -295,13 +295,13 @@ class astrometryUnitTest(unittest.TestCase):
         ra[2]=7.740864769302191473e-01
         dec[2]=2.758053025017753179e-01
 
-        self.assertRaises(RuntimeError, applyPrecession, ra, dec)
+        self.assertRaises(RuntimeError, _applyPrecession, ra, dec)
 
         #just make sure it runs
-        output=applyPrecession(ra,dec, mjd=pal.epj(2000.0))
+        output=_applyPrecession(ra,dec, mjd=pal.epj(2000.0))
 
 
-    def testApplyProperMotion(self):
+    def test_applyProperMotion(self):
 
         ra=numpy.zeros((3),dtype=float)
         dec=numpy.zeros((3),dtype=float)
@@ -336,7 +336,7 @@ class astrometryUnitTest(unittest.TestCase):
         #The proper motion arguments in this function are weird
         #because there was a misunderstanding when the baseline
         #SLALIB data was made.
-        output=applyProperMotion(ra,dec,pm_ra*numpy.cos(dec),pm_dec/numpy.cos(dec),
+        output=_applyProperMotion(ra,dec,pm_ra*numpy.cos(dec),pm_dec/numpy.cos(dec),
                                  radiansFromArcsec(parallax),v_rad,epoch=ep,
                                  mjd=self.obs_metadata.mjd)
 
@@ -348,7 +348,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[1][2],2.758844356561930278e-01,6)
 
 
-    def testAppGeoFromICRS(self):
+    def test_appGeoFromICRS(self):
         ra=numpy.zeros((3),dtype=float)
         dec=numpy.zeros((3),dtype=float)
         pm_ra=numpy.zeros((3),dtype=float)
@@ -384,7 +384,7 @@ class astrometryUnitTest(unittest.TestCase):
         #The proper motion arguments in this function are weird
         #because there was a misunderstanding when the baseline
         #SLALIB data was made.
-        output=appGeoFromICRS(ra,dec,pm_ra=pm_ra*numpy.cos(dec), pm_dec=pm_dec/numpy.cos(dec),
+        output=_appGeoFromICRS(ra,dec,pm_ra=pm_ra*numpy.cos(dec), pm_dec=pm_dec/numpy.cos(dec),
                               parallax=radiansFromArcsec(parallax),v_rad=v_rad, epoch=ep,
                               mjd=mjd)
 
@@ -395,7 +395,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[0][2],7.408639821342507537e-01,6)
         self.assertAlmostEqual(output[1][2],2.703229189890907214e-01,6)
 
-    def testObservedFromAppGeo(self):
+    def test_observedFromAppGeo(self):
         """
         Note: this routine depends on Aopqk which fails if zenith distance
         is too great (or, at least, it won't warn you if the zenith distance
@@ -424,7 +424,7 @@ class astrometryUnitTest(unittest.TestCase):
                                      boundLength=0.05,
                                      phoSimMetaData=self.metadata)
 
-        output=observedFromAppGeo(ra,dec, wavelength=wv, obs_metadata=obs_metadata)
+        output=_observedFromAppGeo(ra,dec, wavelength=wv, obs_metadata=obs_metadata)
 
         self.assertAlmostEqual(output[0][0],2.547475965605183745e+00,6)
         self.assertAlmostEqual(output[1][0],5.187045152602967057e-01,6)
@@ -435,7 +435,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[0][2],7.743528611421227614e-01,6)
         self.assertAlmostEqual(output[1][2],2.755070101670137328e-01,6)
 
-        output=observedFromAppGeo(ra,dec,altAzHr=True, wavelength=wv, obs_metadata=obs_metadata)
+        output=_observedFromAppGeo(ra,dec,altAzHr=True, wavelength=wv, obs_metadata=obs_metadata)
 
         self.assertAlmostEqual(output[0][0],2.547475965605183745e+00,6)
         self.assertAlmostEqual(output[1][0],5.187045152602967057e-01,6)
@@ -452,7 +452,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[2][2],5.275840601437552513e-01,6)
         self.assertAlmostEqual(output[3][2],5.479759580847959555e+00,6)
 
-        output=observedFromAppGeo(ra,dec,includeRefraction=False,
+        output=_observedFromAppGeo(ra,dec,includeRefraction=False,
                                   wavelength=wv, obs_metadata=obs_metadata)
 
         self.assertAlmostEqual(output[0][0],2.549091783674975353e+00,6)
@@ -464,7 +464,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[0][2],7.740875471580924705e-01,6)
         self.assertAlmostEqual(output[1][2],2.758055401087299296e-01,6)
 
-        output=observedFromAppGeo(ra,dec,includeRefraction=False,
+        output=_observedFromAppGeo(ra,dec,includeRefraction=False,
                                   altAzHr=True, wavelength=wv, obs_metadata=obs_metadata)
 
         self.assertAlmostEqual(output[0][0],2.549091783674975353e+00,6)
@@ -482,7 +482,7 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertAlmostEqual(output[2][2],5.271912536356709866e-01,6)
         self.assertAlmostEqual(output[3][2],5.479759580847959555e+00,6)
 
-    def testObservedFromAppGeo_NoRefraction(self):
+    def test_observedFromAppGeo_NoRefraction(self):
 
         ra=numpy.zeros((3),dtype=float)
         dec=numpy.zeros((3),dtype=float)
@@ -500,7 +500,7 @@ class astrometryUnitTest(unittest.TestCase):
                                      boundLength=0.05,
                                      phoSimMetaData=self.metadata)
 
-        output=observedFromAppGeo(ra,dec,altAzHr=True,
+        output=_observedFromAppGeo(ra,dec,altAzHr=True,
                                   includeRefraction=False, obs_metadata=obs_metadata)
 
         self.assertAlmostEqual(output[0][0],2.549091783674975353e+00,6)

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -7,7 +7,7 @@ from lsst.utils import getPackageDir
 
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.coordUtils.utils import ReturnCamera
-from lsst.sims.coordUtils import calculatePupilCoordinates
+from lsst.sims.coordUtils import pupilCoordsFromRaDec
 from lsst.sims.coordUtils import observedFromICRS
 from lsst.sims.coordUtils import chipNameFromRaDec, \
                                  chipNameFromPupilCoords, \
@@ -44,7 +44,7 @@ class ChipNameTest(unittest.TestCase):
         raList, decList = observedFromICRS(raListRaw, decListRaw, obs_metadata=obs,
                                            epoch=2000.0)
 
-        xpList, ypList = calculatePupilCoordinates(raList, decList,
+        xpList, ypList = pupilCoordsFromRaDec(raList, decList,
                                                    obs_metadata=obs,
                                                    epoch=2000.0)
 
@@ -220,7 +220,7 @@ class ChipNameTest(unittest.TestCase):
             raList, decList = observedFromICRS(raListRaw, decListRaw, obs_metadata=obs,
                                                epoch=2000.0)
 
-            xpList, ypList = calculatePupilCoordinates(raList, decList,
+            xpList, ypList = pupilCoordsFromRaDec(raList, decList,
                                                        obs_metadata=obs,
                                                        epoch=2000.0)
 

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1225,6 +1225,168 @@ class ConversionFromPixelTest(unittest.TestCase):
         self.assertTrue(numpy.isnan(yPupTest[5]))
 
 
+    def testRaDecExceptions(self):
+        """
+        Test that raDecFromPupilCoords raises exceptions when it is supposed to
+        """
+        nStars = 20
+        ra0 = 45.0
+        dec0 = -19.0
+        obs = ObservationMetaData(unrefractedRA=ra0, unrefractedDec=dec0,
+                                  mjd=43525.0, rotSkyPos=145.0)
+
+        xPixList = numpy.random.random_sample(nStars)*4000.0
+        yPixList = numpy.random.random_sample(nStars)*4000.0
+
+        chipDexList = numpy.random.random_integers(0, len(self.camera), nStars)
+        chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]] for ii in chipDexList]
+
+        # test that an error is raised if you do not pass in a camera
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                           obs_metadata=obs, epoch=2000.0)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without specifying a camera")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                            obs_metadata=obs, epoch=2000.0)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without specifying a camera")
+
+        # test that an error is raised if you do not pass in an epoch
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                           obs_metadata=obs, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without specifying an epoch")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                            obs_metadata=obs, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without specifying an epoch")
+
+        # test that an error is raised if you do not pass in an ObservationMetaData
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                           epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without an ObservationMetaData")
+
+        # test that an error is raised if you do not pass in an ObservationMetaData
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                            epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You cannot call raDecFromPixelCoords without an ObservationMetaData")
+
+        # test that an error is raised if you pass in an ObservationMetaData
+        # without an mjd
+        obsDummy = ObservationMetaData(unrefractedRA=ra0, unrefractedDec=dec0, rotSkyPos=95.0)
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                           obs_metadata=obsDummy,
+                                           epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "The ObservationMetaData in raDecFromPixelCoords must have an mjd")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                            obs_metadata=obsDummy,
+                                            epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "The ObservationMetaData in raDecFromPixelCoords must have an mjd")
+
+
+        # test that an error is raised if you pass in an ObservationMetaData
+        # without a rotSkyPos
+        obsDummy = ObservationMetaData(unrefractedRA=ra0, unrefractedDec=dec0, mjd=43243.0)
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                           obs_metadata=obsDummy,
+                                           epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+                                            obs_metadata=obsDummy,
+                                            epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
+
+
+        # test that an error is raised if you pass in lists of pixel coordinates,
+        # rather than numpy arrays
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(list(xPixList), yPixList,
+                                           chipNameList, obs_metadata=obs,
+                                           epoch=2000.0, camera=self.camera)
+
+        self.assertEqual(context.exception.message,
+                         "You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, list(yPixList),
+                                           chipNameList, obs_metadata=obs,
+                                           epoch=2000.0, camera=self.camera)
+
+        self.assertEqual(context.exception.message,
+                         "You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(list(xPixList), yPixList,
+                                            chipNameList, obs_metadata=obs,
+                                            epoch=2000.0, camera=self.camera)
+
+        self.assertEqual(context.exception.message,
+                         "You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, list(yPixList),
+                                            chipNameList, obs_metadata=obs,
+                                            epoch=2000.0, camera=self.camera)
+
+        self.assertEqual(context.exception.message,
+                         "You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
+
+
+        # test that an error is raised if you pass in mismatched lists of
+        # xPix and yPix
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList[0:13], chipNameList,
+                                           obs_metadata=obs, epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You passed 20 xPix coordinates but 13 yPix coordinates "\
+                         + "to raDecFromPixelCoords")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList[0:13], chipNameList,
+                                            obs_metadata=obs, epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You passed 20 xPix coordinates but 13 yPix coordinates "\
+                         + "to raDecFromPixelCoords")
+
+        # test that an error is raised if you do not pass in the same number of chipNames
+        # as pixel coordinates
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = raDecFromPixelCoords(xPixList, yPixList, ['Det22']*22,
+                                           obs_metadata=obs, epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You passed 20 pixel coordinate pairs but 22 chip names to "\
+                         + "raDecFromPixelCoords")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, ['Det22']*22,
+                                            obs_metadata=obs, epoch=2000.0, camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         "You passed 20 pixel coordinate pairs but 22 chip names to "\
+                         + "raDecFromPixelCoords")
+
+
+
+
 def suite():
     utilsTests.init()
     suites = []

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1183,6 +1183,12 @@ class ConversionFromPixelTest(unittest.TestCase):
         dy = arcsecFromRadians(yPupTest-yPupList)
         numpy.testing.assert_array_almost_equal(dy, numpy.zeros(len(dy)), 9)
 
+        ctNaN = 0
+        for x, y in zip(xPupTest, yPupTest):
+            if numpy.isnan(x) or numpy.isnan(y):
+                ctNaN += 1
+        self.assertTrue(ctNaN<len(xPupTest)/10)
+
 
 def suite():
     utilsTests.init()

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -580,6 +580,11 @@ class PixelCoordTest(unittest.TestCase):
         We will use that to set the control values for our unit test.
 
         Note: This unit test will fail if the test camera ever changes.
+
+        Note: Because we have already tested the self-consistency of
+        pixelCoordsFromPupilCoords and pixelCoordsFromRaDec, we will
+        only be testing pixelCoordsFromPupilCoords here, because it
+        is easier.
         """
 
         arcsecPerPixel = 0.02
@@ -647,6 +652,7 @@ class PixelCoordTest(unittest.TestCase):
         numpy.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
         numpy.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
 
+
     def testOffChipResults(self):
         """
         Test that the results of the pixelCoords methods make sense in the case
@@ -659,6 +665,11 @@ class PixelCoordTest(unittest.TestCase):
         set the control values for our unit test.
 
         Note: This unit test will fail if the test camera ever changes.
+
+        Note: Because we have already tested the self-consistency of
+        pixelCoordsFromPupilCoords and pixelCoordsFromRaDec, we will
+        only be testing pixelCoordsFromPupilCoords here, because it
+        is easier.
         """
 
         arcsecPerPixel = 0.02

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1542,6 +1542,8 @@ class ConversionFromPixelTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
 
 
+
+
 def suite():
     utilsTests.init()
     suites = []

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -25,6 +25,8 @@ from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoords, \
 
 from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
 
+from lsst.sims.coordUtils import raDecFromPixelCoords, _raDecFromPixelCoords
+
 class ChipNameTest(unittest.TestCase):
 
     @classmethod

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -829,6 +829,31 @@ class PixelCoordTest(unittest.TestCase):
 
 
 
+    def testDistortion(self):
+        """
+        Make sure that the results from pixelCoordsFromPupilCoords are different
+        if includeDistortion is True as compared to if includeDistortion is False
+
+        Note: This test passes because the test camera has a pincushion distortion.
+        If we take that away, the test will no longer pass.
+        """
+        nStars = 100
+        xp = radiansFromArcsec((numpy.random.random_sample(100)-0.5)*100.0)
+        yp = radiansFromArcsec((numpy.random.random_sample(100)-0.5)*100.0)
+
+        xu, yu = pixelCoordsFromPupilCoords(xp, yp, camera=self.camera, includeDistortion=False)
+        xd, yd = pixelCoordsFromPupilCoords(xp, yp, camera=self.camera, includeDistortion=True)
+
+        # just verify that the distorted versus undistorted coordinates vary in the
+        # 4th decimal place
+        with self.assertRaises(AssertionError) as context:
+            numpy.testing.assert_array_almost_equal(xu, xd, 4)
+
+        with self.assertRaises(AssertionError) as context:
+            numpy.testing.assert_array_almost_equal(yu, yd, 4)
+
+
+
 class FocalPlaneCoordTest(unittest.TestCase):
 
     @classmethod
@@ -1487,6 +1512,34 @@ class ConversionFromPixelTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(yPixTest, yPixList, 6)
 
 
+
+    def testDistortion(self):
+        """
+        Make sure that the results from pupilCoordsFromPixelCoords are different
+        if includeDistortion is True as compared to if includeDistortion is False
+
+        Note: This test passes because the test camera has a pincushion distortion.
+        If we take that away, the test will no longer pass.
+        """
+        nStars = 200
+        xPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
+        yPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
+
+        chipDexList = numpy.random.random_integers(0, len(self.camera)-1, nStars)
+        chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]].getName() for ii in chipDexList]
+
+        xu, yu = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=self.camera,
+                                            includeDistortion=False)
+
+        xd, yd = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=self.camera,
+                                            includeDistortion=True)
+
+        # just verify that the distorted versus undistorted coordinates vary in the 4th decimal
+        with self.assertRaises(AssertionError) as context:
+            numpy.testing.assert_array_almost_equal(arcsecFromRadians(xu), arcsecFromRadians(xd), 4)
+
+        with self.assertRaises(AssertionError) as context:
+            numpy.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
 
 
 def suite():

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -9,11 +9,11 @@ from lsst.sims.utils import ObservationMetaData
 from lsst.sims.coordUtils.utils import ReturnCamera
 from lsst.sims.coordUtils import calculatePupilCoordinates
 from lsst.sims.coordUtils import observedFromICRS
-from lsst.sims.coordUtils import findChipNameFromRaDec, \
-                                 findChipNameFromPupilCoords, \
-                                 _findChipNameFromRaDec
+from lsst.sims.coordUtils import chipNameFromRaDec, \
+                                 chipNameFromPupilCoords, \
+                                 _chipNameFromRaDec
 
-class FindChipNameTest(unittest.TestCase):
+class ChipNameTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -27,7 +27,7 @@ class FindChipNameTest(unittest.TestCase):
 
     def testRuns(self):
         """
-        Test that findChipName runs, and that the various iterations of that method
+        Test that chipName runs, and that the various iterations of that method
         are all self-consistent
         """
         nStars = 100
@@ -48,17 +48,17 @@ class FindChipNameTest(unittest.TestCase):
                                                    obs_metadata=obs,
                                                    epoch=2000.0)
 
-        names1 = findChipNameFromRaDec(raList, decList,
-                                        obs_metadata=obs,
-                                        epoch=2000.0,
-                                        camera=self.camera)
+        names1 = chipNameFromRaDec(raList, decList,
+                                   obs_metadata=obs,
+                                   epoch=2000.0,
+                                   camera=self.camera)
 
-        names2 = _findChipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
-                                         obs_metadata=obs,
-                                         epoch=2000.0,
-                                         camera=self.camera)
+        names2 = _chipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
+                                    obs_metadata=obs,
+                                    epoch=2000.0,
+                                    camera=self.camera)
 
-        names3 = findChipNameFromPupilCoords(xpList, ypList, camera=self.camera)
+        names3 = chipNameFromPupilCoords(xpList, ypList, camera=self.camera)
 
         numpy.testing.assert_array_equal(names1, names2)
         numpy.testing.assert_array_equal(names1, names3)
@@ -88,115 +88,115 @@ class FindChipNameTest(unittest.TestCase):
 
         # verify that an exception is raised if you do not pass in a camera
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromPupilCoords(xpList, ypList)
+            chipNameFromPupilCoords(xpList, ypList)
         self.assertTrue('No camera defined' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+            chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
         self.assertTrue('No camera defined' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+            _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
         self.assertTrue('No camera defined' in context.exception.message)
 
         # verify that an exception is raised if you do not pass in a numpy array
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromPupilCoords(list(xpList), ypList)
+            chipNameFromPupilCoords(list(xpList), ypList)
         self.assertTrue('numpy arrays' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(list(xpList), ypList, obs_metadata=obs, epoch=2000.0)
+            _chipNameFromRaDec(list(xpList), ypList, obs_metadata=obs, epoch=2000.0)
         self.assertTrue('numpy arrays' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromPupilCoords(xpList, list(ypList))
+            chipNameFromPupilCoords(xpList, list(ypList))
         self.assertTrue('numpy arrays' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, list(ypList), obs_metadata=obs, epoch=2000.0)
+            _chipNameFromRaDec(xpList, list(ypList), obs_metadata=obs, epoch=2000.0)
         self.assertTrue('numpy arrays' in context.exception.message)
 
         # verify that an exception is raised if the two coordinate arrays contain
         # different numbers of elements
         xpDummy = numpy.random.random_sample(nStars/2)
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
+            chipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
         self.assertTrue('xPupils' in context.exception.message)
         self.assertTrue('yPupils' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
+            chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
                                   camera=self.camera)
         self.assertTrue('RAs' in context.exception.message)
         self.assertTrue('Decs' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
+            _chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
                                    camera=self.camera)
         self.assertTrue('RAs' in context.exception.message)
         self.assertTrue('Decs' in context.exception.message)
 
 
-        # verify that an exception is raised if you call findChipNameFromRaDec
+        # verify that an exception is raised if you call chipNameFromRaDec
         # without an epoch
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
+            chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
         self.assertTrue('epoch' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
+            _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
         self.assertTrue('epoch' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
-        # verify that an exception is raised if you call findChipNameFromRaDec
+        # verify that an exception is raised if you call chipNameFromRaDec
         # without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+            chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
         self.assertTrue('ObservationMetaData' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+            _chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
         self.assertTrue('ObservationMetaData' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
-        # verify that an exception is raised if you call findChipNameFromRaDec
+        # verify that an exception is raised if you call chipNameFromRaDec
         # with an ObservationMetaData that has no mjd
         obsDummy = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-112.0,
                                        rotSkyPos=112.0)
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+            chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
         self.assertTrue('mjd' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+            _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
         self.assertTrue('mjd' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
-        # verify that an exception is raised if you all findChipNameFromRaDec
+        # verify that an exception is raised if you all chipNameFromRaDec
         # using an ObservationMetaData without a rotSkyPos
         obsDummy = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-112.0,
                                        mjd=52350.0)
         with self.assertRaises(RuntimeError) as context:
-            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+            chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
         self.assertTrue('rotSkyPos' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+            _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
         self.assertTrue('rotSkyPos' in context.exception.message)
-        self.assertTrue('findChipName' in context.exception.message)
+        self.assertTrue('chipName' in context.exception.message)
 
 
     def testNaNbecomesNone(self):
         """
-        Test that findChipName maps NaNs and Nones in RA, Dec, and
+        Test that chipName maps NaNs and Nones in RA, Dec, and
         pupil coordinates to None as chip name
         """
         nStars = 100
@@ -224,13 +224,13 @@ class FindChipNameTest(unittest.TestCase):
                                                        obs_metadata=obs,
                                                        epoch=2000.0)
 
-            names1 = findChipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
+            names1 = chipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
                                             camera=self.camera)
 
-            names2 = _findChipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
+            names2 = _chipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
                                             obs_metadata=obs, epoch=2000.0, camera=self.camera)
 
-            names3 = findChipNameFromPupilCoords(xpList, ypList, camera=self.camera)
+            names3 = chipNameFromPupilCoords(xpList, ypList, camera=self.camera)
 
             numpy.testing.assert_array_equal(names1, names2)
             numpy.testing.assert_array_equal(names1, names3)
@@ -248,7 +248,7 @@ class FindChipNameTest(unittest.TestCase):
 def suite():
     utilsTests.init()
     suites = []
-    suites += unittest.makeSuite(FindChipNameTest)
+    suites += unittest.makeSuite(ChipNameTest)
     return unittest.TestSuite(suites)
 
 def run(shouldExit=False):

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -10,10 +10,10 @@ from lsst.sims.utils import ObservationMetaData
 from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
 from lsst.sims.coordUtils import findChipName, calculatePixelCoordinates
 from lsst.sims.coordUtils.utils import ReturnCamera
-from lsst.sims.coordUtils import raDecFromPixelCoordinates
+from lsst.sims.coordUtils import _raDecFromPixelCoordinates
 from lsst.sims.coordUtils import pupilCoordinatesFromPixelCoordinates
 from lsst.sims.coordUtils import calculateFocalPlaneCoordinates
-from lsst.sims.coordUtils import observedFromICRS, calculatePupilCoordinates
+from lsst.sims.coordUtils import _observedFromICRS, _calculatePupilCoordinates
 
 class CameraUtilsUnitTest(unittest.TestCase):
 
@@ -32,7 +32,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
         ra = numpy.array(numpy.radians(obs.unrefractedRA) - numpy.array([1.01, 1.02])*numpy.radians(1.0/3600.0))
         dec = numpy.array(numpy.radians(obs.unrefractedDec) - numpy.array([2.02, 2.01])*numpy.radians(1.0/3600.0))
 
-        ra, dec = observedFromICRS(ra, dec, obs_metadata=obs, epoch=2000.0)
+        ra, dec = _observedFromICRS(ra, dec, obs_metadata=obs, epoch=2000.0)
 
         xPupil = numpy.array([-0.000262243770, -0.00000234])
         yPupil = numpy.array([0.000199467792, 0.000189334])
@@ -241,7 +241,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
         ra = numpy.random.random_sample(nSamples)*radiansFromArcsec(100.0) + numpy.radians(obs.unrefractedRA)
         dec = numpy.random.random_sample(nSamples)*radiansFromArcsec(100.0) + numpy.radians(obs.unrefractedDec)
 
-        pupilCoordinateArray = calculatePupilCoordinates(ra, dec, obs_metadata=obs,
+        pupilCoordinateArray = _calculatePupilCoordinates(ra, dec, obs_metadata=obs,
                                                          epoch=2000.0)
 
         pixelCoordinateArray = calculatePixelCoordinates(ra=ra, dec=dec,
@@ -280,7 +280,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
                                   rotSkyPos=23.0,
                                   mjd=52000.0)
 
-        raTrue, decTrue = observedFromICRS(numpy.array([numpy.radians(raCenter)]),
+        raTrue, decTrue = _observedFromICRS(numpy.array([numpy.radians(raCenter)]),
                                            numpy.array([numpy.radians(decCenter)]),
                                            obs_metadata=obs, epoch=epoch)
 
@@ -298,7 +298,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
         ra = numpy.array(ra)
         dec = numpy.array(dec)
 
-        xp, yp = calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
+        xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
         chipNameList = findChipName(xPupil=xp, yPupil=yp, obs_metadata=obs, epoch=epoch,
                                     camera=camera)
         xPixList, yPixList = calculatePixelCoordinates(xPupil=xp, yPupil=yp, chipNames=chipNameList,
@@ -315,7 +315,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
 
 
 
-    def testRaDecFromPixelCoordinates(self):
+    def test_raDecFromPixelCoordinates(self):
         """
         Test conversion from pixel coordinates to Ra, Dec
         """
@@ -333,7 +333,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
                                   rotSkyPos=23.0,
                                   mjd=52000.0)
 
-        raTrue, decTrue = observedFromICRS(numpy.array([numpy.radians(raCenter)]),
+        raTrue, decTrue = _observedFromICRS(numpy.array([numpy.radians(raCenter)]),
                                            numpy.array([numpy.radians(decCenter)]),
                                            obs_metadata=obs, epoch=epoch)
 
@@ -355,7 +355,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
         pixelList = calculatePixelCoordinates(ra=ra, dec=dec, chipNames=chipNameList, obs_metadata=obs,
                                            epoch=epoch, camera=camera)
 
-        raTest, decTest = raDecFromPixelCoordinates(pixelList[0], pixelList[1], chipNameList,
+        raTest, decTest = _raDecFromPixelCoordinates(pixelList[0], pixelList[1], chipNameList,
                                                     obs_metadata=obs, epoch=epoch, camera=camera)
 
 
@@ -409,7 +409,7 @@ class CameraUtilsUnitTest(unittest.TestCase):
         obs = ObservationMetaData(unrefractedRA=45.0, unrefractedDec=87.0, rotSkyPos=65.0,
                                   mjd=43520.0)
 
-        raCenter, decCenter = observedFromICRS(numpy.array([obs._unrefractedRA]),
+        raCenter, decCenter = _observedFromICRS(numpy.array([obs._unrefractedRA]),
                                                numpy.array([obs._unrefractedDec]),
                                                obs_metadata=obs, epoch=2000.0)
 

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -298,22 +298,22 @@ class PixelCoordTest(unittest.TestCase):
         # pass in a camera
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList)
-        self.assertTrue('camera' in context.exception.message)
-        self.assertTrue('pixel' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'Camera not specified.  Cannot calculate pixel coordinates.')
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList, obs_metadata=obs,
                                  epoch=2000.0)
-        self.assertTrue('camera' in context.exception.message)
-        self.assertTrue('pixel' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'Camera not specified.  Cannot calculate pixel coordinates.')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(numpy.radians(raList),
                                   numpy.radians(decList),
                                   obs_metadata=obs,
                                   epoch=2000.0)
-        self.assertTrue('camera' in context.exception.message)
-        self.assertTrue('pixel' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'Camera not specified.  Cannot calculate pixel coordinates.')
 
 
         # test that an exception is raised when you pass in something
@@ -321,7 +321,16 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(list(xpList), ypList,
                                        camera=self.camera)
-        self.assertTrue('numpy array' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of xPupil and yPupil ' \
+                         + 'to pixelCoordsFromPupilCoords')
+
+        with self.assertRaises(RuntimeError) as context:
+            pixelCoordsFromPupilCoords(xpList, list(ypList),
+                                       camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of xPupil and yPupil ' \
+                         + 'to pixelCoordsFromPupilCoords')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(list(numpy.radians(raList)),
@@ -329,7 +338,19 @@ class PixelCoordTest(unittest.TestCase):
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
-        self.assertTrue('numpy array' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of RA and Dec ' \
+                         + 'to pixelCoordsFromRaDec')
+
+        with self.assertRaises(RuntimeError) as context:
+            _pixelCoordsFromRaDec(numpy.radians(raList),
+                                  list(numpy.radians(decList)),
+                                  obs_metadata=obs,
+                                  epoch=2000.0,
+                                  camera=self.camera)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of RA and Dec ' \
+                         + 'to pixelCoordsFromRaDec')
         # do not need to run the above test on pixelCoordsFromRaDec,
         # because the conversion from degrees to radians  that happens
         # inside that method automatically casts lists as numpy arrays
@@ -340,20 +361,18 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList[0:10],
                                        camera=self.camera)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' xPupil ' in context.exception.message)
-        self.assertTrue(' yPupil ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 xPupil and 10 yPupil coordinates ' \
+                         + 'to pixelCoordsFromPupilCoords')
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList[0:10],
                                  obs_metadata=obs,
                                  epoch=2000.0,
                                  camera=self.camera)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' RA ' in context.exception.message)
-        self.assertTrue(' Dec ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 RA and 10 Dec coordinates ' \
+                         'to pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(numpy.radians(raList),
@@ -361,10 +380,9 @@ class PixelCoordTest(unittest.TestCase):
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' RA ' in context.exception.message)
-        self.assertTrue(' Dec ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 RA and 10 Dec coordinates ' \
+                         'to pixelCoordsFromRaDec')
 
 
         # test that an error is raised if you pass an incorrect
@@ -372,20 +390,16 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList, chipNames=['Det22']*10,
                                  camera=self.camera)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' points ' in context.exception.message)
-        self.assertTrue(' chipNames ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 points but 10 chipNames to pixelCoordsFromPupilCoords')
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList, chipNames=['Det22']*10,
                                  camera=self.camera,
                                  obs_metadata=obs,
                                  epoch=2000.0)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' points ' in context.exception.message)
-        self.assertTrue(' chipNames ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(numpy.radians(raList),
@@ -394,10 +408,8 @@ class PixelCoordTest(unittest.TestCase):
                                   camera=self.camera,
                                   obs_metadata=obs,
                                   epoch=2000.0)
-        self.assertTrue(' 100 ' in context.exception.message)
-        self.assertTrue(' 10 ' in context.exception.message)
-        self.assertTrue(' points ' in context.exception.message)
-        self.assertTrue(' chipNames ' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
 
         # test that an exception is raised if you call one of the
         # pixelCoordsFromRaDec methods without an epoch

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1,452 +1,153 @@
+from __future__ import with_statement
 import os
 import numpy
 import unittest
 import lsst.utils.tests as utilsTests
 from lsst.utils import getPackageDir
 
-import lsst.afw.cameraGeom.testUtils as camTestUtils
-import lsst.afw.geom as afwGeom
 from lsst.sims.utils import ObservationMetaData
-from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
-from lsst.sims.coordUtils import findChipName, calculatePixelCoordinates
 from lsst.sims.coordUtils.utils import ReturnCamera
-from lsst.sims.coordUtils import _raDecFromPixelCoordinates
-from lsst.sims.coordUtils import pupilCoordinatesFromPixelCoordinates
-from lsst.sims.coordUtils import calculateFocalPlaneCoordinates
-from lsst.sims.coordUtils import _observedFromICRS, _calculatePupilCoordinates
+from lsst.sims.coordUtils import findChipNameFromRaDec, \
+                                 findChipNameFromPupilCoords, \
+                                 _findChipNameFromRaDec
 
-class CameraUtilsUnitTest(unittest.TestCase):
+class FindChipNameTest(unittest.TestCase):
 
-    def testCameraCoordsExceptions(self):
+    @classmethod
+    def setUpClass(cls):
+        cameraDir = getPackageDir('sims_coordUtils')
+        cameraDir = os.path.join(cameraDir, 'tests', 'cameraData')
+        cls.camera = ReturnCamera(cameraDir)
+
+    def setUp(self):
+        numpy.random.seed(45532)
+
+    def testExceptions(self):
         """
-        Test to make sure that focal plane methods raise exceptions when coordinates are improperly
-        specified.
-        """
-
-        obs = ObservationMetaData(unrefractedRA=46.0, unrefractedDec=27.0,
-                                  rotSkyPos=82.0, mjd=52350.0)
-
-        camera = camTestUtils.CameraWrapper().camera
-
-        #these are just values shown heuristically to give an actual chip name
-        ra = numpy.array(numpy.radians(obs.unrefractedRA) - numpy.array([1.01, 1.02])*numpy.radians(1.0/3600.0))
-        dec = numpy.array(numpy.radians(obs.unrefractedDec) - numpy.array([2.02, 2.01])*numpy.radians(1.0/3600.0))
-
-        ra, dec = _observedFromICRS(ra, dec, obs_metadata=obs, epoch=2000.0)
-
-        xPupil = numpy.array([-0.000262243770, -0.00000234])
-        yPupil = numpy.array([0.000199467792, 0.000189334])
-
-        ##########test findChipName
-
-        name = findChipName(ra=ra, dec=dec,
-                            epoch=2000.0,
-                            obs_metadata=obs,
-                            camera=camera)
-
-        self.assertTrue(name[0] is not None)
-
-        name = findChipName(xPupil=xPupil, yPupil=yPupil,
-                            camera=camera)
-
-        self.assertTrue(name[0] is not None)
-
-        #test when specifying no coordinates
-        self.assertRaises(RuntimeError, findChipName)
-
-        #test when specifying both sets fo coordinates
-        self.assertRaises(RuntimeError, findChipName, xPupil=xPupil, yPupil=yPupil,
-                  ra=ra, dec=dec, camera=camera)
-
-        #test when failing to specify camera
-        self.assertRaises(RuntimeError, findChipName, ra=ra, dec=dec,
-                          obs_metadata=obs, epoch=2000.0)
-        self.assertRaises(RuntimeError, findChipName, xPupil=xPupil, yPupil=yPupil)
-
-        #test when failing to specify obs_metadata
-        self.assertRaises(RuntimeError, findChipName, ra=ra, dec=dec, epoch=2000.0,
-                          camera=camera)
-
-        #test when failing to specify epoch
-        self.assertRaises(RuntimeError, findChipName, ra=ra, dec=dec, camera=camera,
-                          obs_metadata=obs)
-
-        #test mismatches
-        self.assertRaises(RuntimeError, findChipName, ra=numpy.array([ra[0]]), dec=dec,
-                            epoch=2000.0,
-                            obs_metadata=obs,
-                            camera=camera)
-
-        self.assertRaises(RuntimeError, findChipName, ra=ra, dec=numpy.array([dec[0]]),
-                            epoch=2000.0,
-                            obs_metadata=obs,
-                            camera=camera)
-
-        self.assertRaises(RuntimeError, findChipName, xPupil=numpy.array([xPupil[0]]), yPupil=yPupil,
-                                        camera=camera)
-        self.assertRaises(RuntimeError, findChipName, xPupil=xPupil, yPupil=numpy.array([yPupil[0]]),
-                                        camera=camera)
-
-        #test lists
-        self.assertRaises(RuntimeError, findChipName, ra=list(ra), dec=dec,
-                            epoch=2000.0,
-                            obs_metadata=obs,
-                            camera=camera)
-
-        self.assertRaises(RuntimeError, findChipName, ra=ra, dec=list(dec),
-                            epoch=2000.0,
-                            obs_metadata=obs,
-                            camera=camera)
-
-        self.assertRaises(RuntimeError, findChipName, xPupil=list(xPupil), yPupil=yPupil,
-                                        camera=camera)
-        self.assertRaises(RuntimeError, findChipName, xPupil=xPupil, yPupil=list(yPupil),
-                                        camera=camera)
-
-
-        ##########test FocalPlaneCoordinates
-
-        #test that it actually runs
-        xx, yy = calculateFocalPlaneCoordinates(xPupil=xPupil, yPupil=yPupil, camera=camera)
-        xx, yy = calculateFocalPlaneCoordinates(ra=ra, dec=dec,
-                                                epoch=2000.0, obs_metadata=obs,
-                                                camera=camera)
-
-        #test without any coordinates
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, camera=camera)
-
-        #test specifying both ra,dec and xPupil,yPupil
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=dec,
-                             xPupil=xPupil, yPupil=yPupil, camera=camera)
-
-        #test without camera
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, xPupil=xPupil, yPupil=yPupil)
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=dec,
-                                        epoch=2000.0, obs_metadata=obs)
-
-        #test without epoch
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=dec,
-                                                obs_metadata=obs,
-                                                camera=camera)
-
-        #test without obs_metadata
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=dec,
-                                               epoch=2000.0,
-                                               camera=camera)
-
-        #test with lists
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, xPupil=list(xPupil), yPupil=yPupil,
-                          camera=camera)
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, xPupil=xPupil, yPupil=list(yPupil),
-                          camera=camera)
-
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=list(ra), dec=dec,
-                                        epoch=2000.0, camera=camera)
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=list(dec),
-                                        epoch=2000.0,
-                                        obs_metadata=obs,
-                                        camera=camera)
-
-        #test mismatches
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, xPupil=numpy.array([xPupil[0]]), yPupil=yPupil,
-                          camera=camera)
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, xPupil=xPupil, yPupil=numpy.array([yPupil[0]]),
-                          camera=camera)
-
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=numpy.array([ra[0]]), dec=dec,
-                                        epoch=2000.0, camera=camera)
-        self.assertRaises(RuntimeError, calculateFocalPlaneCoordinates, ra=ra, dec=numpy.array([dec[0]]),
-                                        epoch=2000.0,
-                                        obs_metadata=obs,
-                                        camera=camera)
-
-
-        ##########test calculatePixelCoordinates
-         #test that it actually runs
-        xx, yy = calculatePixelCoordinates(xPupil=xPupil, yPupil=yPupil, camera=camera)
-        xx, yy = calculatePixelCoordinates(ra=ra, dec=dec,
-                                                epoch=2000.0, obs_metadata=obs,
-                                                camera=camera)
-
-        #test without any coordinates
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, camera=camera)
-
-        #test specifying both ra,dec and xPupil,yPupil
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=dec,
-                             xPupil=xPupil, yPupil=yPupil, camera=camera)
-
-        #test without camera
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=xPupil, yPupil=yPupil)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=dec,
-                                        epoch=2000.0, obs_metadata=obs)
-
-        #test without epoch
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=dec,
-                                                obs_metadata=obs,
-                                                camera=camera)
-
-        #test without obs_metadata
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=dec,
-                                                epoch=2000.0,
-                                                camera=camera)
-
-        #test with lists
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=list(xPupil), yPupil=yPupil,
-                          camera=camera)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=xPupil, yPupil=list(yPupil),
-                          camera=camera)
-
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=list(ra), dec=dec,
-                                        epoch=2000.0, camera=camera)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=list(dec),
-                                        epoch=2000.0,
-                                        obs_metadata=obs,
-                                        camera=camera)
-
-        #test mismatches
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=numpy.array([xPupil[0]]), yPupil=yPupil,
-                          camera=camera)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=xPupil, yPupil=numpy.array([yPupil[0]]),
-                          camera=camera)
-
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=numpy.array([ra[0]]), dec=dec,
-                                        epoch=2000.0, camera=camera)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=numpy.array([dec[0]]),
-                                        epoch=2000.0,
-                                        obs_metadata=obs,
-                                        camera=camera)
-
-        chipNames = findChipName(xPupil=xPupil, yPupil=yPupil, camera=camera)
-        calculatePixelCoordinates(xPupil=xPupil, yPupil=yPupil, chipNames=chipNames, camera=camera)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, xPupil=xPupil, yPupil=yPupil,
-                                        camera=camera, chipNames=[chipNames[0]])
-
-        chipNames=findChipName(ra=ra, dec=dec, obs_metadata=obs, epoch=2000.0,
-                               camera=camera)
-        calculatePixelCoordinates(ra=ra, dec=dec, obs_metadata=obs, epoch=2000.0,
-                                  camera=camera, chipNames=chipNames)
-        self.assertRaises(RuntimeError, calculatePixelCoordinates, ra=ra, dec=dec, obs_metadata=obs,
-                          epoch=2000.0,
-                          camera=camera, chipNames=[chipNames[0]])
-
-
-    def testPixelPos(self):
-        obs = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-35.0,
-                                  rotSkyPos=112.0, mjd=52350.0)
-        numpy.random.seed(42)
-
-        camera = camTestUtils.CameraWrapper().camera
-
-        nSamples = 100
-        ra = numpy.random.random_sample(nSamples)*radiansFromArcsec(100.0) + numpy.radians(obs.unrefractedRA)
-        dec = numpy.random.random_sample(nSamples)*radiansFromArcsec(100.0) + numpy.radians(obs.unrefractedDec)
-
-        pupilCoordinateArray = _calculatePupilCoordinates(ra, dec, obs_metadata=obs,
-                                                         epoch=2000.0)
-
-        pixelCoordinateArray = calculatePixelCoordinates(ra=ra, dec=dec,
-                                                        obs_metadata=obs,
-                                                        epoch=2000.0, camera=camera)
-
-        chipNameList = findChipName(ra=ra, dec=dec,
-                                    obs_metadata=obs, epoch=2000.0, camera=camera)
-        self.assertTrue(numpy.all(numpy.isfinite(pupilCoordinateArray[0])))
-        self.assertTrue(numpy.all(numpy.isfinite(pupilCoordinateArray[1])))
-
-        for x, y, cname in zip(pixelCoordinateArray[0], pixelCoordinateArray[1],
-                               chipNameList):
-            if cname is None:
-                #make sure that x and y are not set if the object doesn't land on a chip
-                self.assertTrue(not numpy.isfinite(x) and not numpy.isfinite(y))
-            else:
-                #make sure the pixel positions are inside the detector bounding box.
-                self.assertTrue(afwGeom.Box2D(camera[cname].getBBox()).contains(afwGeom.Point2D(x,y)))
-
-
-
-    def testPupilFromPixel(self):
-        """
-        Test the conversion between pixel coordinates and pupil coordinates
-        """
-        baseDir = os.path.join(getPackageDir('sims_coordUtils'),'tests','cameraData')
-        camera = ReturnCamera(baseDir)
-        epoch=2000.0
-        raCenter = 25.0
-        decCenter = -10.0
-        obs = ObservationMetaData(unrefractedRA=raCenter,
-                                  unrefractedDec=decCenter,
-                                  boundType='circle',
-                                  boundLength=0.1,
-                                  rotSkyPos=23.0,
-                                  mjd=52000.0)
-
-        raTrue, decTrue = _observedFromICRS(numpy.array([numpy.radians(raCenter)]),
-                                           numpy.array([numpy.radians(decCenter)]),
-                                           obs_metadata=obs, epoch=epoch)
-
-        ra = []
-        dec = []
-
-        dx = 1.0e-4
-
-        for rr in numpy.arange(raTrue-20.0*dx, raTrue+20.0*dx, dx):
-            for dd in numpy.arange(decTrue-20.0*dx, decTrue+20.0*dx, dx):
-                ra.append(rr)
-                dec.append(dd)
-
-
-        ra = numpy.array(ra)
-        dec = numpy.array(dec)
-
-        xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
-        chipNameList = findChipName(xPupil=xp, yPupil=yp, obs_metadata=obs, epoch=epoch,
-                                    camera=camera)
-        xPixList, yPixList = calculatePixelCoordinates(xPupil=xp, yPupil=yp, chipNames=chipNameList,
-                                               obs_metadata=obs, epoch=epoch, camera=camera)
-
-        xpTest, ypTest = pupilCoordinatesFromPixelCoordinates(xPixList, yPixList, chipNameList,
-                                                     camera=camera, obs_metadata=obs, epoch=epoch)
-
-        xpControl = numpy.array([xx if name is not None else numpy.NaN for (xx, name) in zip(xp, chipNameList)])
-        ypControl = numpy.array([yy if name is not None else numpy.NaN for (yy, name) in zip(yp, chipNameList)])
-
-        numpy.testing.assert_array_almost_equal(xpControl, xpTest, decimal=10)
-        numpy.testing.assert_array_almost_equal(ypControl, ypTest, decimal=10)
-
-
-
-    def test_raDecFromPixelCoordinates(self):
-        """
-        Test conversion from pixel coordinates to Ra, Dec
+        Test that exceptions are raised when they should be
         """
 
-        baseDir = os.path.join(getPackageDir('sims_coordUtils'),'tests','cameraData')
-        camera = ReturnCamera(baseDir)
-        epoch=2000.0
+        nStars = 10
+        xpList = numpy.random.random_sample(nStars)*0.1
+        ypList = numpy.random.random_sample(nStars)*0.1
 
-        raCenter = 25.0
-        decCenter = -10.0
-        obs = ObservationMetaData(unrefractedRA=raCenter,
-                                  unrefractedDec=decCenter,
-                                  boundType='circle',
-                                  boundLength=0.1,
-                                  rotSkyPos=23.0,
-                                  mjd=52000.0)
+        obs = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=112.0, mjd=42351.0,
+                                  rotSkyPos=35.0)
 
-        raTrue, decTrue = _observedFromICRS(numpy.array([numpy.radians(raCenter)]),
-                                           numpy.array([numpy.radians(decCenter)]),
-                                           obs_metadata=obs, epoch=epoch)
+        # verify that an exception is raised if you do not pass in a camera
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromPupilCoords(xpList, ypList)
+        self.assertTrue('No camera defined' in context.exception.message)
 
-        ra = []
-        dec = []
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+        self.assertTrue('No camera defined' in context.exception.message)
 
-        dx = 1.0e-4
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+        self.assertTrue('No camera defined' in context.exception.message)
 
-        for rr in numpy.arange(raTrue-20.0*dx, raTrue+20.0*dx, dx):
-            for dd in numpy.arange(decTrue-20.0*dx, decTrue+20.0*dx, dx):
-                ra.append(rr)
-                dec.append(dd)
+        # verify that an exception is raised if you do not pass in a numpy array
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromPupilCoords(list(xpList), ypList)
+        self.assertTrue('numpy arrays' in context.exception.message)
 
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(list(xpList), ypList, obs_metadata=obs, epoch=2000.0)
+        self.assertTrue('numpy arrays' in context.exception.message)
 
-        ra = numpy.array(ra)
-        dec = numpy.array(dec)
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromPupilCoords(xpList, list(ypList))
+        self.assertTrue('numpy arrays' in context.exception.message)
 
-        chipNameList = findChipName(ra=ra, dec=dec, obs_metadata=obs, epoch=epoch, camera=camera)
-        pixelList = calculatePixelCoordinates(ra=ra, dec=dec, chipNames=chipNameList, obs_metadata=obs,
-                                           epoch=epoch, camera=camera)
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, list(ypList), obs_metadata=obs, epoch=2000.0)
+        self.assertTrue('numpy arrays' in context.exception.message)
 
-        raTest, decTest = _raDecFromPixelCoordinates(pixelList[0], pixelList[1], chipNameList,
-                                                    obs_metadata=obs, epoch=epoch, camera=camera)
+        # verify that an exception is raised if the two coordinate arrays contain
+        # different numbers of elements
+        xpDummy = numpy.random.random_sample(nStars/2)
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
+        self.assertTrue('xPupils' in context.exception.message)
+        self.assertTrue('yPupils' in context.exception.message)
 
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
+                                  camera=self.camera)
+        self.assertTrue('RAs' in context.exception.message)
+        self.assertTrue('Decs' in context.exception.message)
 
-
-        raControl = numpy.array([rr if name is not None else numpy.NaN for (rr, name) in zip(ra, chipNameList)])
-        decControl = numpy.array([dd if name is not None else numpy.NaN for (dd, name) in zip(dec, chipNameList)])
-
-        numpy.testing.assert_array_almost_equal(arcsecFromRadians(raControl), arcsecFromRadians(raTest), decimal=10)
-        numpy.testing.assert_array_almost_equal(arcsecFromRadians(decControl), arcsecFromRadians(decTest), decimal=10)
-
-
-    def testFindChipNameNaNPupil(self):
-        """
-        Test that findChipName returns 'None' for objects with NaN pupil coordinates
-        """
-        baseDir = os.path.join(getPackageDir('sims_coordUtils'),'tests','cameraData')
-        camera = ReturnCamera(baseDir)
-
-        nSamples = 100
-        numpy.random.seed(42)
-        xp = radiansFromArcsec(numpy.random.random_sample(nSamples)*100.0)
-        yp = radiansFromArcsec(numpy.random.random_sample(nSamples)*100.0)
-
-        nameList = findChipName(xPupil=xp, yPupil=yp, camera=camera)
-        for name in nameList:
-            self.assertTrue(name is not None)
-
-        xp[4] = numpy.NaN
-        yp[4] = numpy.NaN
-
-        xp[10] = numpy.NaN
-
-        yp[15] = numpy.NaN
-
-        nameList2 = findChipName(xPupil=xp, yPupil=yp, camera=camera)
-        for ix in range(len(nameList2)):
-            if ix!=4 and ix!=10 and ix!=15:
-                self.assertTrue(nameList2[ix]==nameList[ix])
-                self.assertFalse(nameList2[ix] is None)
-            else:
-                self.assertTrue(nameList2[ix] is None)
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
+                                   camera=self.camera)
+        self.assertTrue('RAs' in context.exception.message)
+        self.assertTrue('Decs' in context.exception.message)
 
 
-    def testFindChipNameNaNRaDec(self):
-        """
-        Test that findChipName returns 'None' for objects with NaN RA, Dec coordinates
-        """
-        baseDir = os.path.join(getPackageDir('sims_coordUtils'),'tests','cameraData')
-        camera = ReturnCamera(baseDir)
+        # verify that an exception is raised if you call findChipNameFromRaDec
+        # without an epoch
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
+        self.assertTrue('epoch' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        obs = ObservationMetaData(unrefractedRA=45.0, unrefractedDec=87.0, rotSkyPos=65.0,
-                                  mjd=43520.0)
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
+        self.assertTrue('epoch' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        raCenter, decCenter = _observedFromICRS(numpy.array([obs._unrefractedRA]),
-                                               numpy.array([obs._unrefractedDec]),
-                                               obs_metadata=obs, epoch=2000.0)
+        # verify that an exception is raised if you call findChipNameFromRaDec
+        # without an ObservationMetaData
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+        self.assertTrue('ObservationMetaData' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        nSamples = 100
-        numpy.random.seed(42)
-        raList = radiansFromArcsec(numpy.random.random_sample(nSamples)*100.0) + raCenter[0]
-        decList = radiansFromArcsec(numpy.random.random_sample(nSamples)*100.0) + decCenter[0]
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+        self.assertTrue('ObservationMetaData' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        nameList = findChipName(ra=raList, dec=decList, obs_metadata=obs, camera=camera, epoch=2000.0)
+        # verify that an exception is raised if you call findChipNameFromRaDec
+        # with an ObservationMetaData that has no mjd
+        obsDummy = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-112.0,
+                                       rotSkyPos=112.0)
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+                                  camera=self.camera)
+        self.assertTrue('mjd' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        for name in nameList:
-            self.assertTrue(name is not None)
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+                                  camera=self.camera)
+        self.assertTrue('mjd' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        raList[4] = numpy.NaN
-        decList[4] = numpy.NaN
+        # verify that an exception is raised if you all findChipNameFromRaDec
+        # using an ObservationMetaData without a rotSkyPos
+        obsDummy = ObservationMetaData(unrefractedRA=25.0, unrefractedDec=-112.0,
+                                       mjd=52350.0)
+        with self.assertRaises(RuntimeError) as context:
+            findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+                                  camera=self.camera)
+        self.assertTrue('rotSkyPos' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        raList[10] = numpy.NaN
+        with self.assertRaises(RuntimeError) as context:
+            _findChipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
+                                  camera=self.camera)
+        self.assertTrue('rotSkyPos' in context.exception.message)
+        self.assertTrue('findChipName' in context.exception.message)
 
-        decList[15] = numpy.NaN
 
-        raList[30] = raCenter[0] + numpy.pi
-
-        decList[40] = decCenter[0] + numpy.pi
-
-        nameList2 = findChipName(ra=raList, dec=decList, obs_metadata=obs, camera=camera, epoch=2000.0)
-        for ix in range(len(nameList2)):
-            if ix!=4 and ix!=10 and ix!=15 and ix!=30 and ix!=40:
-                self.assertTrue(nameList2[ix]==nameList[ix])
-                self.assertFalse(nameList2[ix] is None)
-            else:
-                self.assertTrue(nameList2[ix] is None)
 
 
 def suite():
     utilsTests.init()
     suites = []
-    suites += unittest.makeSuite(CameraUtilsUnitTest)
+    suites += unittest.makeSuite(FindChipNameTest)
     return unittest.TestSuite(suites)
 
 def run(shouldExit=False):

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -93,80 +93,93 @@ class ChipNameTest(unittest.TestCase):
         # verify that an exception is raised if you do not pass in a camera
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(xpList, ypList)
-        self.assertTrue('No camera defined' in context.exception.message)
+        self.assertEqual('No camera defined.  Cannot run chipName.',
+                          context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
-        self.assertTrue('No camera defined' in context.exception.message)
+        self.assertEqual('No camera defined.  Cannot run chipName.',
+                          context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
-        self.assertTrue('No camera defined' in context.exception.message)
+        self.assertEqual('No camera defined.  Cannot run chipName.',
+                          context.exception.message)
 
         # verify that an exception is raised if you do not pass in a numpy array
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(list(xpList), ypList)
-        self.assertTrue('numpy arrays' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of ' \
+                         + 'xPupil and yPupil to chipNameFromPupilCoords')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(list(xpList), ypList, obs_metadata=obs, epoch=2000.0)
-        self.assertTrue('numpy arrays' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                        'You need to pass numpy arrays of RA and Dec to chipName')
+
+        with self.assertRaises(RuntimeError) as context:
+            chipNameFromPupilCoords(xpList, list(ypList))
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of ' \
+                         + 'xPupil and yPupil to chipNameFromPupilCoords')
+
+        with self.assertRaises(RuntimeError) as context:
+            _chipNameFromRaDec(xpList, list(ypList), obs_metadata=obs, epoch=2000.0)
+        self.assertEqual(context.exception.message,
+                         'You need to pass numpy arrays of RA and Dec to chipName')
         # do not need to run the above test on chipNameFromRaDec because
         # the conversion from degrees to radians that happens inside that
         # method automatically casts lists as numpy arrays
 
-        with self.assertRaises(RuntimeError) as context:
-            chipNameFromPupilCoords(xpList, list(ypList))
-        self.assertTrue('numpy arrays' in context.exception.message)
-
-        with self.assertRaises(RuntimeError) as context:
-            _chipNameFromRaDec(xpList, list(ypList), obs_metadata=obs, epoch=2000.0)
-        self.assertTrue('numpy arrays' in context.exception.message)
 
         # verify that an exception is raised if the two coordinate arrays contain
         # different numbers of elements
         xpDummy = numpy.random.random_sample(nStars/2)
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
-        self.assertTrue('xPupils' in context.exception.message)
-        self.assertTrue('yPupils' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed %d xPupils and ' % (nStars/2) \
+                         + '%d yPupils to chipName.' % nStars)
 
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
                                   camera=self.camera)
-        self.assertTrue('RAs' in context.exception.message)
-        self.assertTrue('Decs' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed %d RAs and ' % (nStars/2) \
+                         + '%d Decs to chipName.' % nStars)
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
                                    camera=self.camera)
-        self.assertTrue('RAs' in context.exception.message)
-        self.assertTrue('Decs' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You passed %d RAs and ' % (nStars/2) \
+                         + '%d Decs to chipName.' % nStars)
 
 
         # verify that an exception is raised if you call chipNameFromRaDec
         # without an epoch
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
-        self.assertTrue('epoch' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an epoch into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
-        self.assertTrue('epoch' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an epoch into chipName')
 
         # verify that an exception is raised if you call chipNameFromRaDec
         # without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
-        self.assertTrue('ObservationMetaData' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
-        self.assertTrue('ObservationMetaData' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData into chipName')
 
         # verify that an exception is raised if you call chipNameFromRaDec
         # with an ObservationMetaData that has no mjd
@@ -175,14 +188,14 @@ class ChipNameTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
-        self.assertTrue('mjd' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData with an mjd into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
-        self.assertTrue('mjd' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData with an mjd into chipName')
 
         # verify that an exception is raised if you all chipNameFromRaDec
         # using an ObservationMetaData without a rotSkyPos
@@ -191,14 +204,14 @@ class ChipNameTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
-        self.assertTrue('rotSkyPos' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData with a rotSkyPos into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
                                   camera=self.camera)
-        self.assertTrue('rotSkyPos' in context.exception.message)
-        self.assertTrue('chipName' in context.exception.message)
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData with a rotSkyPos into chipName')
 
 
     def testNaNbecomesNone(self):

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -135,6 +135,38 @@ class AstrometryDegreesTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(dAlt, numpy.zeros(self.nStars), 9)
 
 
+    def testObservedFromICRS(self):
+        obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,
+                                  mjd=43572.0)
+        for pmRaList in [self.pm_raList, None]:
+            for pmDecList in [self.pm_decList, None]:
+                for pxList in [self.pxList, None]:
+                    for vRadList in [self.v_radList, None]:
+                        for includeRefraction in [True, False]:
+
+
+                            raRad, decRad = coordUtils._observedFromICRS(self.raList, self.decList,
+                                                                         pm_ra=pmRaList, pm_dec=pmDecList,
+                                                                         parallax=pxList, v_rad=vRadList,
+                                                                         obs_metadata=obs, epoch=2000.0,
+                                                                         includeRefraction=includeRefraction)
+
+                            raDeg, decDeg = coordUtils.observedFromICRS(numpy.degrees(self.raList), numpy.degrees(self.decList),
+                                                                         pm_ra=arcsecFromRadians(pmRaList),
+                                                                         pm_dec=arcsecFromRadians(pmDecList),
+                                                                         parallax=arcsecFromRadians(pxList),
+                                                                         v_rad=vRadList,
+                                                                         obs_metadata=obs, epoch=2000.0,
+                                                                     includeRefraction=includeRefraction)
+
+
+                            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+                            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
+
+                            dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
+                            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
+
+
 
 def suite():
     utilsTests.init()

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -189,6 +189,29 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
 
+    def testCalculatePupilCoordinates(self):
+        obs = ObservationMetaData(unrefractedRA=23.5, unrefractedDec=-115.0, mjd=42351.0, rotSkyPos=127.0)
+
+        # need to make sure the test points are tightly distributed around the bore site, or
+        # PALPY will throw an error
+        raList = numpy.random.random_sample(self.nStars)*numpy.radians(1.0) + numpy.radians(23.5)
+        decList = numpy.random.random_sample(self.nStars)*numpy.radians(1.0) + numpy.radians(-115.0)
+
+        xpControl, ypControl = coordUtils._calculatePupilCoordinates(raList, decList,
+                                                                     obs_metadata=obs, epoch=2000.0)
+
+        xpTest, ypTest = coordUtils.calculatePupilCoordinates(numpy.degrees(raList), numpy.degrees(decList),
+                                                              obs_metadata=obs, epoch=2000.0)
+
+        dx = arcsecFromRadians(xpControl-xpTest)
+        numpy.testing.assert_array_almost_equal(dx, numpy.zeros(self.nStars), 9)
+
+        dy = arcsecFromRadians(ypControl-ypTest)
+        numpy.testing.assert_array_almost_equal(dy, numpy.zeros(self.nStars), 9)
+
+
+
+
 def suite():
     utilsTests.init()
     suites = []

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -8,7 +8,7 @@ import lsst.sims.coordUtils as coordUtils
 class AstrometryDegreesTest(unittest.TestCase):
 
     def setUp(self):
-        self.nStars = 100
+        self.nStars = 10
         numpy.random.seed(8273)
         self.raList = numpy.random.random_sample(self.nStars)*2.0*numpy.pi
         self.decList = (numpy.random.random_sample(self.nStars)-0.5)*numpy.pi

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -172,14 +172,14 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
 
-    def testRaDecFromPupilCoordinates(self):
+    def testraDecFromPupilCoords(self):
         obs = ObservationMetaData(unrefractedRA=23.5, unrefractedDec=-115.0, mjd=42351.0, rotSkyPos=127.0)
 
         xpList = numpy.random.random_sample(100)*0.25*numpy.pi
         ypList = numpy.random.random_sample(100)*0.25*numpy.pi
 
-        raRad, decRad = coordUtils._raDecFromPupilCoordinates(xpList, ypList, obs_metadata=obs, epoch=2000.0)
-        raDeg, decDeg = coordUtils.raDecFromPupilCoordinates(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+        raRad, decRad = coordUtils._raDecFromPupilCoords(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+        raDeg, decDeg = coordUtils.raDecFromPupilCoords(xpList, ypList, obs_metadata=obs, epoch=2000.0)
 
         dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
         numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(len(xpList)), 9)
@@ -189,7 +189,7 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
 
-    def testCalculatePupilCoordinates(self):
+    def testpupilCoordsFromRaDec(self):
         obs = ObservationMetaData(unrefractedRA=23.5, unrefractedDec=-115.0, mjd=42351.0, rotSkyPos=127.0)
 
         # need to make sure the test points are tightly distributed around the bore site, or
@@ -197,10 +197,10 @@ class AstrometryDegreesTest(unittest.TestCase):
         raList = numpy.random.random_sample(self.nStars)*numpy.radians(1.0) + numpy.radians(23.5)
         decList = numpy.random.random_sample(self.nStars)*numpy.radians(1.0) + numpy.radians(-115.0)
 
-        xpControl, ypControl = coordUtils._calculatePupilCoordinates(raList, decList,
+        xpControl, ypControl = coordUtils._pupilCoordsFromRaDec(raList, decList,
                                                                      obs_metadata=obs, epoch=2000.0)
 
-        xpTest, ypTest = coordUtils.calculatePupilCoordinates(numpy.degrees(raList), numpy.degrees(decList),
+        xpTest, ypTest = coordUtils.pupilCoordsFromRaDec(numpy.degrees(raList), numpy.degrees(decList),
                                                               obs_metadata=obs, epoch=2000.0)
 
         dx = arcsecFromRadians(xpControl-xpTest)

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -117,14 +117,24 @@ class AstrometryDegreesTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
 
-            raRad, decRad, altRad, azRad = coordUtils._observedFromAppGeo(self.raList, self.decList,
-                                                                          includeRefraction=includeRefraction,
-                                                                          altAzHr=True, obs_metadata=obs)
+            raDec, altAz = coordUtils._observedFromAppGeo(self.raList, self.decList,
+                                                          includeRefraction=includeRefraction,
+                                                          altAzHr=True, obs_metadata=obs)
 
-            raDeg, decDeg, altDeg, azDeg = coordUtils.observedFromAppGeo(numpy.degrees(self.raList),
-                                                                         numpy.degrees(self.decList),
-                                                                         includeRefraction=includeRefraction,
-                                                                         altAzHr=True, obs_metadata=obs)
+            raRad = raDec[0]
+            decRad = raDec[1]
+            altRad = altAz[0]
+            azRad = altAz[1]
+
+            raDec, altAz = coordUtils.observedFromAppGeo(numpy.degrees(self.raList),
+                                                         numpy.degrees(self.decList),
+                                                         includeRefraction=includeRefraction,
+                                                         altAzHr=True, obs_metadata=obs)
+
+            raDeg = raDec[0]
+            decDeg = raDec[1]
+            altDeg = altAz[0]
+            azDeg = altAz[1]
 
             dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
             numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -36,8 +36,6 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
     def testApplyProperMotion(self):
-
-
         for mjd in self.mjdList:
             raRad, decRad = coordUtils._applyProperMotion(self.raList, self.decList,
                                                           self.pm_raList, self.pm_decList,
@@ -70,6 +68,27 @@ class AstrometryDegreesTest(unittest.TestCase):
 
             self.assertAlmostEqual((ra-raRad)/(ra-numpy.radians(raDeg)), 1.0, 9)
             self.assertAlmostEqual((dec-decRad)/(dec-numpy.radians(decDeg)), 1.0, 9)
+
+
+    def testAppGeoFromICRS(self):
+        for mjd in self.mjdList:
+            raRad, decRad = coordUtils._appGeoFromICRS(self.raList, self.decList,
+                                                          self.pm_raList, self.pm_decList,
+                                                          self.pxList, self.v_radList, mjd=mjd)
+
+            raDeg, decDeg = coordUtils.appGeoFromICRS(numpy.degrees(self.raList),
+                                                         numpy.degrees(self.decList),
+                                                         arcsecFromRadians(self.pm_raList),
+                                                         arcsecFromRadians(self.pm_decList),
+                                                         arcsecFromRadians(self.pxList),
+                                                         self.v_radList, mjd=mjd)
+
+            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
+                                                    numpy.ones(self.nStars), 9)
+
+            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
+                                                    numpy.ones(self.nStars), 9)
+
 
 
 

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -1,0 +1,39 @@
+import unittest
+import numpy
+import lsst.utils.tests as utilsTests
+import lsst.sims.coordUtils as coordUtils
+
+class AstrometryDegreesTest(unittest.TestCase):
+
+    def setUp(self):
+        numpy.random.seed(8273)
+        self.raList = numpy.random.random_sample(100)*2.0*numpy.pi
+        self.decList = (numpy.random.random_sample(100)-0.5)*numpy.pi
+        self.mjdList = numpy.random.random_sample(10)*5000.0 + 52000.0
+
+
+    def testApplyPrecession(self):
+        for mjd in self.mjdList:
+            raRad, decRad = coordUtils._applyPrecession(self.raList,
+                                                        self.decList,
+                                                        mjd=mjd)
+
+            raDeg, decDeg = coordUtils.applyPrecession(numpy.degrees(self.raList),
+                                                       numpy.degrees(self.decList),
+                                                       mjd=mjd)
+
+            numpy.testing.assert_array_almost_equal(raRad, numpy.radians(raDeg), 10)
+            numpy.testing.assert_array_almost_equal(decRad, numpy.radians(decDeg), 10)
+
+
+def suite():
+    utilsTests.init()
+    suites = []
+    suites += unittest.makeSuite(AstrometryDegreesTest)
+    return unittest.TestSuite(suites)
+
+def run(shouldExit=False):
+    utilsTests.run(suite(),shouldExit)
+
+if __name__ == "__main__":
+    run(True)

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -172,6 +172,23 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
 
+    def testRaDecFromPupilCoordinates(self):
+        obs = ObservationMetaData(unrefractedRA=23.5, unrefractedDec=-115.0, mjd=42351.0, rotSkyPos=127.0)
+
+        xpList = numpy.random.random_sample(100)*0.25*numpy.pi
+        ypList = numpy.random.random_sample(100)*0.25*numpy.pi
+
+        raRad, decRad = coordUtils._raDecFromPupilCoordinates(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+        raDeg, decDeg = coordUtils.raDecFromPupilCoordinates(xpList, ypList, obs_metadata=obs, epoch=2000.0)
+
+        dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+        numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(len(xpList)), 9)
+
+        dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
+        numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(len(xpList)), 9)
+
+
+
 def suite():
     utilsTests.init()
     suites = []

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -72,23 +72,27 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
     def testAppGeoFromICRS(self):
-        for mjd in self.mjdList:
-            raRad, decRad = coordUtils._appGeoFromICRS(self.raList, self.decList,
-                                                          self.pm_raList, self.pm_decList,
-                                                          self.pxList, self.v_radList, mjd=mjd)
+        mjd = 42350.0
+        for pmRaList in [self.pm_raList, None]:
+            for pmDecList in [self.pm_decList, None]:
+                for pxList in [self.pxList, None]:
+                    for vRadList in [self.v_radList, None]:
+                        raRad, decRad = coordUtils._appGeoFromICRS(self.raList, self.decList,
+                                                                   pmRaList, pmDecList,
+                                                                   pxList, vRadList, mjd=mjd)
 
-            raDeg, decDeg = coordUtils.appGeoFromICRS(numpy.degrees(self.raList),
-                                                         numpy.degrees(self.decList),
-                                                         arcsecFromRadians(self.pm_raList),
-                                                         arcsecFromRadians(self.pm_decList),
-                                                         arcsecFromRadians(self.pxList),
-                                                         self.v_radList, mjd=mjd)
+                        raDeg, decDeg = coordUtils.appGeoFromICRS(numpy.degrees(self.raList),
+                                                                 numpy.degrees(self.decList),
+                                                                 arcsecFromRadians(pmRaList),
+                                                                 arcsecFromRadians(pmDecList),
+                                                                 arcsecFromRadians(pxList),
+                                                                 vRadList, mjd=mjd)
 
-            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
-            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
+                        dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+                        numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
 
-            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
-            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
+                        dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+                        numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
 
 

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -12,6 +12,10 @@ class AstrometryDegreesTest(unittest.TestCase):
         self.raList = numpy.random.random_sample(self.nStars)*2.0*numpy.pi
         self.decList = (numpy.random.random_sample(self.nStars)-0.5)*numpy.pi
         self.mjdList = numpy.random.random_sample(10)*5000.0 + 52000.0
+        self.pm_raList = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
+        self.pm_decList = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
+        self.pxList = radiansFromArcsec(numpy.random.random_sample(self.nStars)*2.0)
+        self.v_radList = numpy.random.random_sample(self.nStars)*500.0 - 250.0
 
 
     def testApplyPrecession(self):
@@ -32,22 +36,19 @@ class AstrometryDegreesTest(unittest.TestCase):
 
 
     def testApplyProperMotion(self):
-        pm_ra = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
-        pm_dec = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
-        px = radiansFromArcsec(numpy.random.random_sample(self.nStars)*2.0)
-        v_rad = numpy.random.random_sample(self.nStars)*500.0 - 250.0
+
 
         for mjd in self.mjdList:
             raRad, decRad = coordUtils._applyProperMotion(self.raList, self.decList,
-                                                          pm_ra, pm_dec, px, v_rad,
-                                                          mjd=mjd)
+                                                          self.pm_raList, self.pm_decList,
+                                                          self.pxList, self.v_radList, mjd=mjd)
 
             raDeg, decDeg = coordUtils.applyProperMotion(numpy.degrees(self.raList),
                                                          numpy.degrees(self.decList),
-                                                         arcsecFromRadians(pm_ra),
-                                                         arcsecFromRadians(pm_dec),
-                                                         arcsecFromRadians(px),
-                                                         v_rad, mjd=mjd)
+                                                         arcsecFromRadians(self.pm_raList),
+                                                         arcsecFromRadians(self.pm_decList),
+                                                         arcsecFromRadians(self.pxList),
+                                                         self.v_radList, mjd=mjd)
 
             numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
                                                     numpy.ones(self.nStars), 9)
@@ -55,6 +56,20 @@ class AstrometryDegreesTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
                                                     numpy.ones(self.nStars), 9)
 
+
+        for ra, dec, pm_ra, pm_dec, px, v_rad in \
+        zip(self.raList, self.decList, self.pm_raList, self.pm_decList, \
+        self.pxList, self.v_radList):
+
+            raRad, decRad = coordUtils._applyProperMotion(ra, dec, pm_ra, pm_dec, px, v_rad,
+                                                          mjd=self.mjdList[0])
+
+            raDeg, decDeg = coordUtils.applyProperMotion(numpy.degrees(ra), numpy.degrees(dec),
+                                                         arcsecFromRadians(pm_ra), arcsecFromRadians(pm_dec),
+                                                         arcsecFromRadians(px), v_rad, mjd=self.mjdList[0])
+
+            self.assertAlmostEqual((ra-raRad)/(ra-numpy.radians(raDeg)), 1.0, 9)
+            self.assertAlmostEqual((dec-decRad)/(dec-numpy.radians(decDeg)), 1.0, 9)
 
 
 

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -1,14 +1,16 @@
 import unittest
 import numpy
 import lsst.utils.tests as utilsTests
+from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
 import lsst.sims.coordUtils as coordUtils
 
 class AstrometryDegreesTest(unittest.TestCase):
 
     def setUp(self):
+        self.nStars = 100
         numpy.random.seed(8273)
-        self.raList = numpy.random.random_sample(100)*2.0*numpy.pi
-        self.decList = (numpy.random.random_sample(100)-0.5)*numpy.pi
+        self.raList = numpy.random.random_sample(self.nStars)*2.0*numpy.pi
+        self.decList = (numpy.random.random_sample(self.nStars)-0.5)*numpy.pi
         self.mjdList = numpy.random.random_sample(10)*5000.0 + 52000.0
 
 
@@ -22,8 +24,38 @@ class AstrometryDegreesTest(unittest.TestCase):
                                                        numpy.degrees(self.decList),
                                                        mjd=mjd)
 
-            numpy.testing.assert_array_almost_equal(raRad, numpy.radians(raDeg), 10)
-            numpy.testing.assert_array_almost_equal(decRad, numpy.radians(decDeg), 10)
+            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
+                                                    numpy.ones(self.nStars), 9)
+
+            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
+                                                    numpy.ones(self.nStars), 9)
+
+
+    def testApplyProperMotion(self):
+        pm_ra = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
+        pm_dec = radiansFromArcsec(numpy.random.random_sample(self.nStars)*10.0 - 5.0)
+        px = radiansFromArcsec(numpy.random.random_sample(self.nStars)*2.0)
+        v_rad = numpy.random.random_sample(self.nStars)*500.0 - 250.0
+
+        for mjd in self.mjdList:
+            raRad, decRad = coordUtils._applyProperMotion(self.raList, self.decList,
+                                                          pm_ra, pm_dec, px, v_rad,
+                                                          mjd=mjd)
+
+            raDeg, decDeg = coordUtils.applyProperMotion(numpy.degrees(self.raList),
+                                                         numpy.degrees(self.decList),
+                                                         arcsecFromRadians(pm_ra),
+                                                         arcsecFromRadians(pm_dec),
+                                                         arcsecFromRadians(px),
+                                                         v_rad, mjd=mjd)
+
+            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
+                                                    numpy.ones(self.nStars), 9)
+
+            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
+                                                    numpy.ones(self.nStars), 9)
+
+
 
 
 def suite():

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -2,6 +2,7 @@ import unittest
 import numpy
 import lsst.utils.tests as utilsTests
 from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
+from lsst.sims.utils import ObservationMetaData
 import lsst.sims.coordUtils as coordUtils
 
 class AstrometryDegreesTest(unittest.TestCase):
@@ -28,11 +29,11 @@ class AstrometryDegreesTest(unittest.TestCase):
                                                        numpy.degrees(self.decList),
                                                        mjd=mjd)
 
-            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
-                                                    numpy.ones(self.nStars), 9)
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
 
-            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
-                                                    numpy.ones(self.nStars), 9)
+            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
 
     def testApplyProperMotion(self):
@@ -48,11 +49,11 @@ class AstrometryDegreesTest(unittest.TestCase):
                                                          arcsecFromRadians(self.pxList),
                                                          self.v_radList, mjd=mjd)
 
-            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
-                                                    numpy.ones(self.nStars), 9)
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
 
-            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
-                                                    numpy.ones(self.nStars), 9)
+            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
 
         for ra, dec, pm_ra, pm_dec, px, v_rad in \
@@ -66,8 +67,8 @@ class AstrometryDegreesTest(unittest.TestCase):
                                                          arcsecFromRadians(pm_ra), arcsecFromRadians(pm_dec),
                                                          arcsecFromRadians(px), v_rad, mjd=self.mjdList[0])
 
-            self.assertAlmostEqual((ra-raRad)/(ra-numpy.radians(raDeg)), 1.0, 9)
-            self.assertAlmostEqual((dec-decRad)/(dec-numpy.radians(decDeg)), 1.0, 9)
+            self.assertAlmostEqual(arcsecFromRadians(raRad-numpy.radians(raDeg)), 0.0, 9)
+            self.assertAlmostEqual(arcsecFromRadians(decRad-numpy.radians(decDeg)), 0.0, 9)
 
 
     def testAppGeoFromICRS(self):
@@ -83,12 +84,55 @@ class AstrometryDegreesTest(unittest.TestCase):
                                                          arcsecFromRadians(self.pxList),
                                                          self.v_radList, mjd=mjd)
 
-            numpy.testing.assert_array_almost_equal((raRad-self.raList)/(numpy.radians(raDeg)-self.raList),
-                                                    numpy.ones(self.nStars), 9)
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
 
-            numpy.testing.assert_array_almost_equal((decRad-self.decList)/(numpy.radians(decDeg)-self.decList),
-                                                    numpy.ones(self.nStars), 9)
+            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
+
+
+    def testObservedFromAppGeo(self):
+        obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,
+                                  mjd=43572.0)
+
+        for includeRefraction in [True, False]:
+            raRad, decRad = coordUtils._observedFromAppGeo(self.raList, self.decList,
+                                                           includeRefraction=includeRefraction,
+                                                           altAzHr=False, obs_metadata=obs)
+
+            raDeg, decDeg = coordUtils.observedFromAppGeo(numpy.degrees(self.raList),
+                                                          numpy.degrees(self.decList),
+                                                          includeRefraction=includeRefraction,
+                                                          altAzHr=False, obs_metadata=obs)
+
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
+
+            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
+
+
+            raRad, decRad, altRad, azRad = coordUtils._observedFromAppGeo(self.raList, self.decList,
+                                                                          includeRefraction=includeRefraction,
+                                                                          altAzHr=True, obs_metadata=obs)
+
+            raDeg, decDeg, altDeg, azDeg = coordUtils.observedFromAppGeo(numpy.degrees(self.raList),
+                                                                         numpy.degrees(self.decList),
+                                                                         includeRefraction=includeRefraction,
+                                                                         altAzHr=True, obs_metadata=obs)
+
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
+
+            dDec = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
+
+            dAz = arcsecFromRadians(azRad-numpy.radians(azDeg))
+            numpy.testing.assert_array_almost_equal(dAz, numpy.zeros(self.nStars), 9)
+
+            dAlt = arcsecFromRadians(altRad-numpy.radians(altDeg))
+            numpy.testing.assert_array_almost_equal(dAlt, numpy.zeros(self.nStars), 9)
 
 
 

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -3,8 +3,8 @@ import unittest
 import lsst.utils.tests as utilsTests
 
 from lsst.sims.utils import ObservationMetaData, _nativeLonLatFromRaDec
-from lsst.sims.coordUtils import calculatePupilCoordinates, observedFromICRS
-from lsst.sims.coordUtils import raDecFromPupilCoordinates
+from lsst.sims.coordUtils import _calculatePupilCoordinates, _observedFromICRS
+from lsst.sims.coordUtils import _raDecFromPupilCoordinates
 
 class PupilCoordinateUnitTest(unittest.TestCase):
 
@@ -24,39 +24,39 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         decShort = numpy.array([1.0])
 
         #test without epoch
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           obs_metadata=obs_metadata)
 
         #test without obs_metadata
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           epoch=2000.0)
 
         #test without unrefractedRA
         dummy = ObservationMetaData(unrefractedDec=obs_metadata.unrefractedDec,
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without unrefractedDec
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without rotSkyPos
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     unrefractedDec=obs_metadata.unrefractedDec,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without mjd
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     unrefractedDec=obs_metadata.unrefractedDec,
                                     rotSkyPos=obs_metadata.rotSkyPos)
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
 
@@ -66,14 +66,14 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
 
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, ra, decShort, epoch=2000.0,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, decShort, epoch=2000.0,
                           obs_metadata=dummy)
 
-        self.assertRaises(RuntimeError, calculatePupilCoordinates, raShort, dec, epoch=2000.0,
+        self.assertRaises(RuntimeError, _calculatePupilCoordinates, raShort, dec, epoch=2000.0,
                           obs_metadata=dummy)
 
         #test that it actually runs
-        test = calculatePupilCoordinates(ra, dec, obs_metadata=obs_metadata, epoch=2000.0)
+        test = _calculatePupilCoordinates(ra, dec, obs_metadata=obs_metadata, epoch=2000.0)
 
 
     def testCardinalDirections(self):
@@ -121,14 +121,14 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                           mjd=mjd,
                                           rotSkyPos=rotSkyPos)
 
-                centerRA, centerDec = observedFromICRS(numpy.array([numpy.radians(obs.unrefractedRA)]),
+                centerRA, centerDec = _observedFromICRS(numpy.array([numpy.radians(obs.unrefractedRA)]),
                                                        numpy.array([numpy.radians(obs.unrefractedDec)]),
                                                        obs_metadata=obs, epoch=epoch)
 
                 #test order E, W, N, S
                 raTest = centerRA[0] + numpy.array([0.01, -0.01, 0.0, 0.0])
                 decTest = centerDec[0] + numpy.array([0.0, 0.0, 0.01, -0.01])
-                x, y = calculatePupilCoordinates(raTest, decTest, obs_metadata=obs, epoch=epoch)
+                x, y = _calculatePupilCoordinates(raTest, decTest, obs_metadata=obs, epoch=epoch)
 
                 lon, lat = _nativeLonLatFromRaDec(raTest, decTest, centerRA[0], centerDec[0])
                 rr = numpy.abs(numpy.cos(lat)/numpy.sin(lat))
@@ -170,15 +170,15 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         numpy.random.seed(42)
         ra = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(raCenter)
         dec = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(decCenter)
-        xp, yp = calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
-        raTest, decTest = raDecFromPupilCoordinates(xp, yp, obs_metadata=obs, epoch=2000.0)
+        xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
+        raTest, decTest = _raDecFromPupilCoordinates(xp, yp, obs_metadata=obs, epoch=2000.0)
         numpy.testing.assert_array_almost_equal(raTest, ra, decimal=10)
         numpy.testing.assert_array_almost_equal(decTest, dec, decimal=10)
 
 
     def testNaNs(self):
         """
-        Test how calculatePupilCoordinates handles improper values
+        Test how _calculatePupilCoordinates handles improper values
         """
         obs = ObservationMetaData(unrefractedRA=42.0, unrefractedDec=-28.0,
                                   rotSkyPos=111.0, mjd=42356.0)
@@ -187,7 +187,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         raList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 + 42.0)
         decList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 -28.0)
 
-        xControl, yControl = calculatePupilCoordinates(raList, decList,
+        xControl, yControl = _calculatePupilCoordinates(raList, decList,
                                                        obs_metadata=obs,
                                                        epoch=2000.0)
 
@@ -197,7 +197,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         decList[20] = numpy.NaN
         raList[30] = numpy.radians(42.0) + numpy.pi
 
-        xTest, yTest = calculatePupilCoordinates(raList, decList,
+        xTest, yTest = _calculatePupilCoordinates(raList, decList,
                                                  obs_metadata=obs,
                                                  epoch=2000.0)
 

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -3,8 +3,8 @@ import unittest
 import lsst.utils.tests as utilsTests
 
 from lsst.sims.utils import ObservationMetaData, _nativeLonLatFromRaDec
-from lsst.sims.coordUtils import _calculatePupilCoordinates, _observedFromICRS
-from lsst.sims.coordUtils import _raDecFromPupilCoordinates
+from lsst.sims.coordUtils import _pupilCoordsFromRaDec, _observedFromICRS
+from lsst.sims.coordUtils import _raDecFromPupilCoords
 
 class PupilCoordinateUnitTest(unittest.TestCase):
 
@@ -24,39 +24,39 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         decShort = numpy.array([1.0])
 
         #test without epoch
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           obs_metadata=obs_metadata)
 
         #test without obs_metadata
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0)
 
         #test without unrefractedRA
         dummy = ObservationMetaData(unrefractedDec=obs_metadata.unrefractedDec,
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without unrefractedDec
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without rotSkyPos
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     unrefractedDec=obs_metadata.unrefractedDec,
                                     mjd=obs_metadata.mjd)
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
         #test without mjd
         dummy = ObservationMetaData(unrefractedRA=obs_metadata.unrefractedRA,
                                     unrefractedDec=obs_metadata.unrefractedDec,
                                     rotSkyPos=obs_metadata.rotSkyPos)
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, dec,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0, obs_metadata=dummy)
 
 
@@ -66,14 +66,14 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                     rotSkyPos=obs_metadata.rotSkyPos,
                                     mjd=obs_metadata.mjd)
 
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, ra, decShort, epoch=2000.0,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, decShort, epoch=2000.0,
                           obs_metadata=dummy)
 
-        self.assertRaises(RuntimeError, _calculatePupilCoordinates, raShort, dec, epoch=2000.0,
+        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, raShort, dec, epoch=2000.0,
                           obs_metadata=dummy)
 
         #test that it actually runs
-        test = _calculatePupilCoordinates(ra, dec, obs_metadata=obs_metadata, epoch=2000.0)
+        test = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=2000.0)
 
 
     def testCardinalDirections(self):
@@ -128,7 +128,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                 #test order E, W, N, S
                 raTest = centerRA[0] + numpy.array([0.01, -0.01, 0.0, 0.0])
                 decTest = centerDec[0] + numpy.array([0.0, 0.0, 0.01, -0.01])
-                x, y = _calculatePupilCoordinates(raTest, decTest, obs_metadata=obs, epoch=epoch)
+                x, y = _pupilCoordsFromRaDec(raTest, decTest, obs_metadata=obs, epoch=epoch)
 
                 lon, lat = _nativeLonLatFromRaDec(raTest, decTest, centerRA[0], centerDec[0])
                 rr = numpy.abs(numpy.cos(lat)/numpy.sin(lat))
@@ -170,15 +170,15 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         numpy.random.seed(42)
         ra = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(raCenter)
         dec = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(decCenter)
-        xp, yp = _calculatePupilCoordinates(ra, dec, obs_metadata=obs, epoch=2000.0)
-        raTest, decTest = _raDecFromPupilCoordinates(xp, yp, obs_metadata=obs, epoch=2000.0)
+        xp, yp = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs, epoch=2000.0)
+        raTest, decTest = _raDecFromPupilCoords(xp, yp, obs_metadata=obs, epoch=2000.0)
         numpy.testing.assert_array_almost_equal(raTest, ra, decimal=10)
         numpy.testing.assert_array_almost_equal(decTest, dec, decimal=10)
 
 
     def testNaNs(self):
         """
-        Test how _calculatePupilCoordinates handles improper values
+        Test how _pupilCoordsFromRaDec handles improper values
         """
         obs = ObservationMetaData(unrefractedRA=42.0, unrefractedDec=-28.0,
                                   rotSkyPos=111.0, mjd=42356.0)
@@ -187,7 +187,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         raList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 + 42.0)
         decList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 -28.0)
 
-        xControl, yControl = _calculatePupilCoordinates(raList, decList,
+        xControl, yControl = _pupilCoordsFromRaDec(raList, decList,
                                                        obs_metadata=obs,
                                                        epoch=2000.0)
 
@@ -197,7 +197,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         decList[20] = numpy.NaN
         raList[30] = numpy.radians(42.0) + numpy.pi
 
-        xTest, yTest = _calculatePupilCoordinates(raList, decList,
+        xTest, yTest = _pupilCoordsFromRaDec(raList, decList,
                                                  obs_metadata=obs,
                                                  epoch=2000.0)
 


### PR DESCRIPTION
This is a fairly large pull request.

I have rewritten all of the coordinate transformation routines so that routines that deal exclusively in radians are named, for example, _observedFromICRS, and routines that deal in sensible units (degrees for RA, Dec; arcseconds for proper motion and parallax) are named observedFromICRS.

I have also broken up methods like findChipName, which used to accept either pupil coordinates or Ra, Dec as arguments, into chipNameFromRaDec and chipNameFromPupilCoords.

I completely rewrote the unit test testCameraUtils.py to more systematically test all of the functionality in CameraUtils.py.

I added the unit test testDegreesVersusRadians.py to test the self-consistency of the degree- and radian-handling methods in AstrometryUtils.py

Obviously, this has impacts on a lot of upstream packages.  There are supporting pull requests in
sims_utils
sims_catalogs_generation
sims_photUtils
sims_catUtils
sims_GalSimInterface
sims_maf
