### PR TITLE
Feature/sim 1370/icrs from observed

### DIFF
--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -12,7 +12,7 @@ __all__ = ["applyRefraction", "refractionCoefficients",
            "_observedFromAppGeo", "observedFromAppGeo",
            "_appGeoFromObserved", "appGeoFromObserved",
            "_observedFromICRS", "observedFromICRS",
-           "_icrsFromObserved",
+           "_icrsFromObserved", "icrsFromObserved",
            "_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
            "_raDecFromPupilCoords", "raDecFromPupilCoords"]
 
@@ -925,6 +925,43 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
                                                includeRefraction = includeRefraction)
 
     return numpy.array([ra_out,dec_out])
+
+
+def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=True):
+    """
+    Convert observed RA, Dec into mean International Celestial Reference Frame (ICRS)
+    RA, Dec.  This method undoes the effects of precession, nutation, aberration (annual
+    and diurnal), and refraction.  It is meant so that users can take pointing RA and Decs,
+    which will be in the observed reference system, and transform them into ICRS for
+    purposes of querying database tables (likely to contain mean ICRS RA, Dec) for objects
+    visible from a given pointing.
+
+    Note: This method is only accurate at angular distances from the sun of greater
+    than 45 degrees and zenith distances of less than 70 degrees.
+
+    This method works in degrees.
+
+    @param [in] ra is the observed RA in degrees.  Must be a numpy array.
+
+    @param [in] dec is the observed Dec in degrees.  Must be a numpy array.
+
+    @param [in] obs_metadata is an ObservationMetaData object describing the
+    telescope pointing.
+
+    @param [in] epoch is the julian epoch (in years) against which the mean
+    equinoxes are measured.
+
+    @param [in] includeRefraction toggles whether or not to correct for refraction
+
+    @param [out] a 2-D numpy array in which the first row is the mean ICRS
+    RA and the second row is the mean ICRS Dec (both in degrees)
+    """
+
+    ra_out, dec_out = _icrsFromObserved(numpy.radians(ra), numpy.radians(dec),
+                                        obs_metadata=obs_metadata,
+                                        epoch=epoch, includeRefraction=includeRefraction)
+
+    return numpy.array([numpy.degrees(ra_out), numpy.degrees(dec_out)])
 
 
 def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=True):

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -958,10 +958,10 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     """
 
     if obs_metadata is None:
-        raise RuntimeError("cannot call icrsFromObserved; obs_metadata is none")
+        raise RuntimeError("cannot call icrsFromObserved; obs_metadata is None")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("cannot call icrsFromObserved; obs_metadata.mjd is none")
+        raise RuntimeError("cannot call icrsFromObserved; obs_metadata.mjd is None")
 
     if epoch is None:
         raise RuntimeError("cannot call icrsFromObserved; you have not specified an epoch")

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -86,7 +86,7 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     Accepts RA and dec as inputs.  Returns corrected RA and dec (in degrees).
 
     Assumes FK5 as the coordinate system
-    units:  ra_in (radians), dec_in (radians)
+    units:  ra_in (degrees), dec_in (degrees)
 
     The precession-nutation matrix is calculated by the palpy.prenut method
     which uses the IAU 2006/2000A model
@@ -297,19 +297,11 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
                    v_rad=None, epoch=2000.0, mjd = None):
     """
     Convert the mean position (RA, Dec) in the International Celestial Reference
-    System (ICRS) to the mean apparent geocentric position in
-    (Ra, Dec)-like coordinates
-
-    Uses PAL mappa routine, which computes precession and nutation
+    System (ICRS) to the mean apparent geocentric position
 
     units:  ra (degrees), dec (degrees), pm_ra (arcsec/year), pm_dec
     (arcsec/year), parallax (arcsec), v_rad (km/sec; positive if receding),
     epoch (Julian years)
-
-    Returns corrected RA and Dec
-
-    This calls palpy.mapqk(z) which accounts for proper motion, parallax,
-    radial velocity, aberration, precession-nutation
 
     @param [in] ra in degrees (ICRS).  Must be a numpy array.
 
@@ -329,8 +321,7 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     @param[in] MJD is the date of the observation
 
     @param [out] a 2-D numpy array in which the first row is the apparent
-    geocentric RA and the second row is the apparent geocentric Dec
-    coordinate (both in degrees)
+    geocentric RA and the second row is the apparent geocentric Dec (both in degrees)
     """
 
     if pm_ra is not None:
@@ -360,19 +351,11 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
                    v_rad=None, epoch=2000.0, mjd = None):
     """
     Convert the mean position (RA, Dec) in the International Celestial Reference
-    System (ICRS) to the mean apparent geocentric position in
-    (Ra, Dec)-like coordinates
-
-    Uses PAL mappa routine, which computes precession and nutation
+    System (ICRS) to the mean apparent geocentric position
 
     units:  ra (radians), dec (radians), pm_ra (radians/year), pm_dec
     (radians/year), parallax (radians), v_rad (km/sec; positive if receding),
     epoch (Julian years)
-
-    Returns corrected RA and Dec
-
-    This calls palpy.mapqk(z) which accounts for proper motion, parallax,
-    radial velocity, aberration, precession-nutation
 
     @param [in] ra in radians (ICRS).  Must be a numpy array.
 
@@ -392,8 +375,7 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     @param[in] MJD is the date of the observation
 
     @param [out] a 2-D numpy array in which the first row is the apparent
-    geocentric RA-like coordinate and the second row is the apparent
-    geocentric Dec-like coordinate (both in radians)
+    geocentric RAand the second row is the apparent geocentric Dec (both in radians)
     """
 
     if mjd is None:
@@ -527,13 +509,10 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 def observedFromAppGeo(ra, dec, includeRefraction = True,
                        altAzHr=False, wavelength=0.5, obs_metadata = None):
     """
-    Convert apparent geocentric (RA, Dec)-like coordinates to observed
-    (RA, Dec)-like coordinates.  More specifically, apply refraction and
-    diurnal aberration.
+    Convert apparent geocentric (RA, Dec) to observed (RA, Dec).  More
+    specifically: apply refraction and diurnal aberration.
 
-    Uses PAL aoppa routines
-
-    This will call palpy.aopqk
+    This method works in degrees.
 
     @param [in] ra is geocentric apparent RA (degrees).  Must be a numpy array.
 
@@ -547,9 +526,7 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
     @param [in] wavelength is effective wavelength in microns (default: 0.5)
 
     @param [in] obs_metadata is an ObservationMetaData characterizing the
-    observation (optional; if not included, the code will try to set it from
-    self assuming it is in an InstanceCatalog daughter class.  If that is not
-    the case, an exception will be raised.)
+    observation.
 
     @param [out] a 2-D numpy array in which the first row is the observed RA
     and the second row is the observed Dec (both in degrees)
@@ -651,13 +628,10 @@ def _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
 def _observedFromAppGeo(ra, dec, includeRefraction = True,
                        altAzHr=False, wavelength=0.5, obs_metadata = None):
     """
-    Convert apparent geocentric (RA, Dec)-like coordinates to observed
-    (RA, Dec)-like coordinates.  More specifically, apply refraction and
-    diurnal aberration.
+    Convert apparent geocentric (RA, Dec) to observed (RA, Dec).  More specifically:
+    apply refraction and diurnal aberration.
 
-    Uses PAL aoppa routines
-
-    This will call palpy.aopqk
+    This method works in radians.
 
     @param [in] ra is geocentric apparent RA (radians).  Must be a numpy array.
 
@@ -728,15 +702,12 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 def appGeoFromObserved(ra, dec, includeRefraction = True,
                         wavelength=0.5, obs_metadata = None):
     """
-    Convert observed (RA, Dec)-like coordinates to apparent geocentric
-    (RA, Dec)-like coordinates.  More specifically, undo the effects of
-    refraction and diurnal aberration.
+    Convert observed (RA, Dec) to apparent geocentric (RA, Dec).  More
+    specifically: undo the effects of refraction and diurnal aberration.
+
+    Note: This method is only accurate at zenith distances less than ~75 degrees.
 
     This method works in degrees.
-
-    Uses PAL aoppa routines
-
-    This will call palpy.oapqk
 
     @param [in] ra is observed RA (degrees).  Must be a numpy array.
 
@@ -765,15 +736,12 @@ def appGeoFromObserved(ra, dec, includeRefraction = True,
 def _appGeoFromObserved(ra, dec, includeRefraction = True,
                         wavelength=0.5, obs_metadata = None):
     """
-    Convert observed (RA, Dec)-like coordinates to apparent geocentric
-    (RA, Dec)-like coordinates.  More specifically, undo the effects of
-    refraction and diurnal aberration.
+    Convert observed (RA, Dec) to apparent geocentric (RA, Dec).
+    More specifically: undo the effects of refraction and diurnal aberration.
+
+    Note: This method is only accurate at zenith distances less than ~ 75 degrees.
 
     This method works in radians.
-
-    Uses PAL aoppa routines
-
-    This will call palpy.oapqk
 
     @param [in] ra is observed RA (radians).  Must be a numpy array.
 
@@ -814,10 +782,12 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
                      obs_metadata=None, epoch=None, includeRefraction=True):
     """
     Convert mean position (RA, Dec) in the International Celestial Reference Frame
-    to observed (RA, Dec)-like coordinates
+    to observed (RA, Dec).
 
     included are precession-nutation, aberration, proper motion, parallax, refraction,
-    radial velocity, diurnal aberration,
+    radial velocity, diurnal aberration.
+
+    This method works in degrees.
 
     @param [in] ra is the unrefracted RA in degrees (ICRS).  Must be a numpy array.
 
@@ -832,9 +802,7 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
     @param [in] v_rad is radial velocity (km/s)
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
-    telescope pointing.  If it is None, the code will try to set it from self
-    assuming that this method is being called from within an InstanceCatalog
-    daughter class.  If that is not the case, an exception will be raised
+    telescope pointing.
 
     @param [in] epoch is the julian epoch (in years) against which the mean
     equinoxes are measured.
@@ -873,10 +841,12 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
                      obs_metadata=None, epoch=None, includeRefraction=True):
     """
     Convert mean position (RA, Dec) in the International Celestial Reference Frame
-    to observed (RA, Dec)-like coordinates
+    to observed (RA, Dec)-like coordinates.
 
     included are precession-nutation, aberration, proper motion, parallax, refraction,
-    radial velocity, diurnal aberration,
+    radial velocity, diurnal aberration.
+
+    This method works in radians.
 
     @param [in] ra is the unrefracted RA in radians (ICRS).  Must be a numpy array.
 
@@ -891,9 +861,7 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
     @param [in] v_rad is radial velocity (km/s)
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
-    telescope pointing.  If it is None, the code will try to set it from self
-    assuming that this method is being called from within an InstanceCatalog
-    daughter class.  If that is not the case, an exception will be raised
+    telescope pointing.
 
     @param [in] epoch is the julian epoch (in years) against which the mean
     equinoxes are measured.
@@ -937,7 +905,7 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
     visible from a given pointing.
 
     Note: This method is only accurate at angular distances from the sun of greater
-    than 45 degrees and zenith distances of less than 70 degrees.
+    than 45 degrees and zenith distances of less than 75 degrees.
 
     This method works in degrees.
 
@@ -974,7 +942,7 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     visible from a given pointing.
 
     Note: This method is only accurate at angular distances from the sun of greater
-    than 45 degrees and zenith distances of less than 70 degrees.
+    than 45 degrees and zenith distances of less than 75 degrees.
 
     This method works in radians.
 
@@ -1122,9 +1090,7 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     @param [in] dec_in in degrees
 
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
-    telescope location and pointing (optional; if not provided, the method will try to
-    get it from the InstanceCatalog member variable, assuming this is part of an
-    InstanceCatalog)
+    telescope location and pointing.
 
     @param [in] epoch is the epoch of mean ra and dec in julian years (optional; if not
     provided, this method will try to get it from the db_obj member variable, assuming this
@@ -1152,9 +1118,7 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     @param [in] dec_in in radians
 
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
-    telescope location and pointing (optional; if not provided, the method will try to
-    get it from the InstanceCatalog member variable, assuming this is part of an
-    InstanceCatalog)
+    telescope location and pointing.
 
     @param [in] epoch is the epoch of mean ra and dec in julian years (optional; if not
     provided, this method will try to get it from the db_obj member variable, assuming this

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -955,7 +955,6 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     @param [out] a 2-D numpy array in which the first row is the mean ICRS
     RA and the second row is the mean ICRS Dec (both in radians)
-
     """
 
     if obs_metadata is None:

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -8,7 +8,7 @@ __all__ = ["applyRefraction", "refractionCoefficients",
            "_applyPrecession", "applyPrecession",
            "_applyProperMotion", "applyProperMotion",
            "_appGeoFromICRS", "appGeoFromICRS",
-           "_icrsFromAppGeo",
+           "_icrsFromAppGeo", "icrsFromAppGeo",
            "_observedFromAppGeo", "observedFromAppGeo",
            "_appGeoFromObserved", "appGeoFromObserved",
            "_observedFromICRS", "observedFromICRS",
@@ -488,6 +488,39 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     raOut, decOut = palpy.ampqkVector(ra, dec, params)
 
     return numpy.array([raOut, decOut])
+
+
+def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
+    """
+    Convert the apparent geocentric position in (RA, Dec) to
+    the mean position in the International Celestial Reference
+    System (ICRS)
+
+    This method undoes the effects of precession, annual aberration,
+    and nutation.  It is meant for mapping pointing RA and Dec (which
+    presumably include the above effects) back to mean ICRS RA and Dec
+    so that the user knows how to query a database of mean RA and Decs
+    for objects observed at a given telescope pointing.
+
+    This method works in degrees.
+
+    @param [in] ra in degrees (apparent geocentric).  Must be a numpy array.
+
+    @param [in] dec in degrees (apparent geocentric).  Must be a numpy array.
+
+    @param [in] epoch is the julian epoch (in years) of the equinox against which to
+    measure RA (default: 2000.0)
+
+    @param[in] MJD is the date of the observation
+
+    @param [out] a 2-D numpy array in which the first row is the mean ICRS RA and
+    the second row is the mean ICRS Dec (both in degrees)
+    """
+
+    raOut, decOut = _icrsFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+                                    epoch=epoch, mjd=mjd)
+
+    return numpy.array([numpy.degrees(raOut), numpy.degrees(decOut)])
 
 
 def observedFromAppGeo(ra, dec, includeRefraction = True,

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -9,7 +9,7 @@ __all__ = ["applyRefraction", "refractionCoefficients",
            "_applyProperMotion", "applyProperMotion",
            "_appGeoFromICRS", "appGeoFromICRS",
            "_observedFromAppGeo", "observedFromAppGeo",
-           "_appGeoFromObserved",
+           "_appGeoFromObserved", "appGeoFromObserved",
            "_observedFromICRS", "observedFromICRS",
            "_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
            "_raDecFromPupilCoords", "raDecFromPupilCoords"]
@@ -642,6 +642,43 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
         az, alt = palpy.de2hVector(hourAngle,decOut,obs_metadata.site.latitude)
         return numpy.array([raOut, decOut]), numpy.array([alt, az])
     return numpy.array([raOut, decOut])
+
+
+def appGeoFromObserved(ra, dec, includeRefraction = True,
+                        wavelength=0.5, obs_metadata = None):
+    """
+    Convert observed (RA, Dec)-like coordinates to apparent geocentric
+    (RA, Dec)-like coordinates.  More specifically, undo the effects of
+    refraction and diurnal aberration.
+
+    This method works in degrees.
+
+    Uses PAL aoppa routines
+
+    This will call palpy.oapqk
+
+    @param [in] ra is observed RA (degrees).  Must be a numpy array.
+
+    @param [in] dec is observed Dec (degrees).  Must be a numpy array.
+
+    @param [in] includeRefraction is a boolean to turn refraction on and off
+
+    @param [in] wavelength is effective wavelength in microns (default: 0.5)
+
+    @param [in] obs_metadata is an ObservationMetaData characterizing the
+    observation.
+
+    @param [out] a 2-D numpy array in which the first row is the apparent
+    geocentric RA and the second row is the apparentGeocentric Dec (both
+    in degrees)
+    """
+
+    raOut, decOut = _appGeoFromObserved(numpy.radians(ra), numpy.radians(dec),
+                                        includeRefraction=includeRefraction,
+                                        wavelength=wavelength,
+                                        obs_metadata=obs_metadata)
+
+    return numpy.array([numpy.degrees(raOut), numpy.degrees(decOut)])
 
 
 def _appGeoFromObserved(ra, dec, includeRefraction = True,

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -456,6 +456,8 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     so that the user knows how to query a database of mean RA and Decs
     for objects observed at a given telescope pointing.
 
+    This method works in radians.
+
     @param [in] ra in radians (apparent geocentric).  Must be a numpy array.
 
     @param [in] dec in radians (apparent geocentric).  Must be a numpy array.
@@ -465,8 +467,8 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     @param[in] MJD is the date of the observation
 
-    @param [out] a 2-D numpy array in which the first row is the apparent
-    mean ICRS RA and the second row is the mean ICRS Dec (both in radians)
+    @param [out] a 2-D numpy array in which the first row is the mean ICRS RA and
+    the second row is the mean ICRS Dec (both in radians)
     """
 
     # Define star independent mean to apparent place parameters

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -414,28 +414,28 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
         parallax=numpy.zeros(len(ra))
 
     # Define star independent mean to apparent place parameters
-    #palpy.mappa calculates the star-independent parameters
-    #needed to correct RA and Dec
-    #e.g the Earth barycentric and heliocentric position and velocity,
-    #the precession-nutation matrix, etc.
+    # palpy.mappa calculates the star-independent parameters
+    # needed to correct RA and Dec
+    # e.g the Earth barycentric and heliocentric position and velocity,
+    # the precession-nutation matrix, etc.
     #
-    #arguments of palpy.mappa are:
-    #epoch of mean equinox to be used (Julian)
+    # arguments of palpy.mappa are:
+    # epoch of mean equinox to be used (Julian)
     #
-    #date (MJD)
+    # date (MJD)
     #
-    #TODO This mjd should be the Barycentric Dynamical Time
+    # TODO This mjd should be the Barycentric Dynamical Time
     prms=palpy.mappa(epoch, mjd)
 
-    #palpy.mapqk does a quick mean to apparent place calculation using
-    #the output of palpy.mappa
+    # palpy.mapqk does a quick mean to apparent place calculation using
+    # the output of palpy.mappa
     #
-    #Taken from the palpy source code (palMap.c which calls both palMappa and palMapqk):
-    #The accuracy is sub-milliarcsecond, limited by the
-    #precession-nutation model (see palPrenut for details).
+    # Taken from the palpy source code (palMap.c which calls both palMappa and palMapqk):
+    # The accuracy is sub-milliarcsecond, limited by the
+    # precession-nutation model (see palPrenut for details).
 
-    #because PAL and ERFA expect proper motion in terms of "coordinate
-    #angle; not true angle" (as stated in erfa/starpm.c documentation)
+    # because PAL and ERFA expect proper motion in terms of "coordinate
+    # angle; not true angle" (as stated in erfa/starpm.c documentation)
     pm_ra_corrected = pm_ra/numpy.cos(dec)
 
     raOut,decOut = palpy.mapqkVector(ra,dec,pm_ra_corrected,pm_dec,arcsecFromRadians(parallax),v_rad,prms)

--- a/python/lsst/sims/coordUtils/AstrometryUtils.py
+++ b/python/lsst/sims/coordUtils/AstrometryUtils.py
@@ -648,8 +648,10 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
                         wavelength=0.5, obs_metadata = None):
     """
     Convert observed (RA, Dec)-like coordinates to apparent geocentric
-    (RA, Dec)-like coordinates.  More specifically, apply refraction and
-    diurnal aberration.
+    (RA, Dec)-like coordinates.  More specifically, undo the effects of
+    refraction and diurnal aberration.
+
+    This method works in radians.
 
     Uses PAL aoppa routines
 

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -515,6 +515,36 @@ class astrometryUnitTest(unittest.TestCase):
                         self.assertLess(distance.max(), 0.01)
 
 
+    def test_icrsFromObservedExceptions(self):
+        """
+        Test that _icrsFromObserved raises exceptions when it is supposed to.
+        """
+        numpy.random.seed(33)
+        ra_in = numpy.random.random_sample(10)
+        dec_in = numpy.random.random_sample(10)
+        with self.assertRaises(RuntimeError) as context:
+            ra_out, dec_out = _icrsFromObserved(ra_in, dec_in, epoch=2000.0)
+        self.assertEqual(context.exception.args[0],
+                         "cannot call icrsFromObserved; obs_metadata is None")
+
+        obs = ObservationMetaData(unrefractedRA=23.0, unrefractedDec=-19.0)
+        with self.assertRaises(RuntimeError) as context:
+            ra_out, dec_out = _icrsFromObserved(ra_in, dec_in, epoch=2000.0, obs_metadata=obs)
+        self.assertEqual(context.exception.args[0],
+                         "cannot call icrsFromObserved; obs_metadata.mjd is None")
+
+        obs = ObservationMetaData(unrefractedRA=23.0, unrefractedDec=-19.0, mjd=52344.0)
+        with self.assertRaises(RuntimeError) as context:
+            ra_out, dec_out = _icrsFromObserved(ra_in, dec_in, obs_metadata=obs)
+        self.assertEqual(context.exception.args[0],
+                         "cannot call icrsFromObserved; you have not specified an epoch")
+
+        with self.assertRaises(RuntimeError) as context:
+            ra_out, dec_out = _icrsFromObserved(ra_in[:3], dec_in, obs_metadata=obs, epoch=2000.0)
+        self.assertEqual(context.exception.args[0],
+                         "You passed 3 RAs but 10 Decs to icrsFromObserved")
+
+
     def test_observedFromAppGeo(self):
         """
         Note: this routine depends on Aopqk which fails if zenith distance

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -149,6 +149,32 @@ class AstrometryDegreesTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(dAlt, numpy.zeros(self.nStars), 9)
 
 
+    def testAppGeoFromObserved(self):
+        obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,
+                                  mjd=43572.0)
+
+        for includeRefraction in (True, False):
+            for wavelength in (0.5, 0.2, 0.3):
+
+                raRad, decRad = coordUtils._appGeoFromObserved(self.raList, self.decList,
+                                                               includeRefraction=includeRefraction,
+                                                               wavelength=wavelength,
+                                                               obs_metadata=obs)
+
+
+                raDeg, decDeg = coordUtils.appGeoFromObserved(numpy.degrees(self.raList), numpy.degrees(self.decList),
+                                                              includeRefraction=includeRefraction,
+                                                              wavelength=wavelength,
+                                                              obs_metadata=obs)
+
+                dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+                numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(len(dRa)), 9)
+
+                dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
+                numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(len(dDec)), 9)
+
+
+
     def testObservedFromICRS(self):
         obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,
                                   mjd=43572.0)

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -174,6 +174,24 @@ class AstrometryDegreesTest(unittest.TestCase):
                 numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(len(dDec)), 9)
 
 
+    def testIcrsFromAppGeo(self):
+
+        for mjd in (53525.0, 54316.3, 58463.7):
+            for epoch in( 2000.0, 1950.0, 2010.0):
+
+                raRad, decRad = coordUtils._icrsFromAppGeo(self.raList, self.decList,
+                                                           epoch=epoch, mjd=mjd)
+
+                raDeg, decDeg = coordUtils.icrsFromAppGeo(numpy.degrees(self.raList),
+                                                          numpy.degrees(self.decList),
+                                                          epoch=epoch, mjd=mjd)
+
+                dRa = arcsecFromRadians(numpy.abs(raRad-numpy.radians(raDeg)))
+                self.assertLess(dRa.max(), 1.0e-9)
+
+                dDec = arcsecFromRadians(numpy.abs(decRad-numpy.radians(decDeg)))
+                self.assertLess(dDec.max(), 1.0e-9)
+
 
     def testObservedFromICRS(self):
         obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,

--- a/tests/testDegreesVersusRadians.py
+++ b/tests/testDegreesVersusRadians.py
@@ -225,6 +225,27 @@ class AstrometryDegreesTest(unittest.TestCase):
                             numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
 
 
+    def testIcrsFromObserved(self):
+        obs = ObservationMetaData(unrefractedRA=35.0, unrefractedDec=-45.0,
+                                  mjd=43572.0)
+
+        for includeRefraction in [True, False]:
+
+            raRad, decRad = coordUtils._icrsFromObserved(self.raList, self.decList,
+                                                         obs_metadata=obs, epoch=2000.0,
+                                                         includeRefraction=includeRefraction)
+
+            raDeg, decDeg = coordUtils.icrsFromObserved(numpy.degrees(self.raList), numpy.degrees(self.decList),
+                                                        obs_metadata=obs, epoch=2000.0,
+                                                        includeRefraction=includeRefraction)
+
+            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
+            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(self.nStars), 9)
+
+            dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
+            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(self.nStars), 9)
+
+
 
     def testraDecFromPupilCoords(self):
         obs = ObservationMetaData(unrefractedRA=23.5, unrefractedDec=-115.0, mjd=42351.0, rotSkyPos=127.0)


### PR DESCRIPTION
We have a lot of methods to go from the mean RA, Dec stored on fatboy to the RA, Dec actually observed by the telescope.  This pull request provides methods to do the backward transformations, so that users can take an observed pointing RA, Dec and convert them into bounds on a SQL query sent to fatboy.

You may need to work off of master in sims_utils to get the unit tests to pass (there were some bugs in the sims_utils routines that caused NaNs to come up in some cases when you asked to transform Alt, Az into RA, Dec; those have been fixed on master).
