### PR TITLE
Feature/sim 1983/wavefront sensor methods

### DIFF
--- a/examples/CameraUtilsExample.ipynb
+++ b/examples/CameraUtilsExample.ipynb
@@ -1,0 +1,296 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook will show how to use the LSST Simulations code which can connect coordinates on the sky (RA, Dec) with coordinates on the LSST camera (pixels).  <b>Note: Before running this notebook, you must install and set up the packages ```obs_lsstSim```, which actually contains the representation of the LSST camera, and ```sims_coordUtils```, which contains the code wrapping obs_lsstSim.  You can get both of these by simply installing and setting up ```lsst_sims```.</b>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's import the representation of the LSST Camera and instantiate it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "from lsst.obs.lsstSim import LsstSimMapper\n",
+    "camera = LsstSimMapper().camera"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The global object ```camera``` now contains a representation of the LSST camera.  ```camera``` is a dict-like object containing ```detector``` objects that characterize the CCDs in the LSST focal plane.  They can be iterated over."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.afw.cameraGeom import SCIENCE, WAVEFRONT, GUIDER, FOCUS\n",
+    "\n",
+    "ccd_type_dict = {}\n",
+    "ccd_type_dict[SCIENCE] = 'science'\n",
+    "ccd_type_dict[WAVEFRONT] = 'wavefront'\n",
+    "ccd_type_dict[GUIDER] = 'guider'\n",
+    "ccd_type_dict[FOCUS] = 'focus'\n",
+    "\n",
+    "for det in camera:\n",
+    "    print('%s %s' % (det.getName(), ccd_type_dict[det.getType()]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see above, in addition to containing a grid of pixels, each detector also has a name and a type.  You can refer to detectors by name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "tt = camera['R:0,4 S:1,0'].getType()\n",
+    "print(ccd_type_dict[tt])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 'R:X,Y S:I,J' is a way of referring to how the chips are layed out in rafts on the camera.  For more information, see https://confluence.lsstcorp.org/display/LSWUG/Representation+of+a+Camera"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The functionality of the ```camera``` object is all defined in the package ```afw.cameraGeom```.  Users wishing to interact directly with the ```camera``` object should consult the documentation and examples provided with that package.  The LSST Simulations stack provides methods that allow you to work with ```camera``` without having to call its methods directly.  Those are the subject of this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding which chip an object lands on"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```sims_coordUtils``` provides a method ```chipNameFromRaDec``` which allows you to specify a position on the sky and get back the name of the chip on which that position falls.  In order to use this method, you must first create an ```ObservationMetaData``` characterizing the direction that the telescope is pointing and how it is rotated with respect to the sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.utils import ObservationMetaData\n",
+    "obs = ObservationMetaData(pointingRA=123.0, pointingDec=-35.6,\n",
+    "                          rotSkyPos=29.0, mjd=59580.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from lsst.sims.coordUtils import chipNameFromRaDec\n",
+    "chipName = chipNameFromRaDec(121.0, -35.2, \n",
+    "                             camera=camera, obs_metadata=obs)\n",
+    "print(chipName)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "You can also pass a numpy array of RA, Dec and get back a list of chip names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "chipNameList = chipNameFromRaDec(np.array([121.0, 121.7, 124.0]),\n",
+    "                                 np.array([-35.2, -35.1, -34.0]),\n",
+    "                                 camera=camera, obs_metadata=obs)\n",
+    "print(chipNameList)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also methods to take (RA, Dec) positions on the sky and transform them into pixel coordinates on the camera.  Note that pixel coordinates are defined on each individual chip (i.e. each chip has its own (0, 0)).  The ```pixelCoordsFromRaDec``` method can accept the kwarg ```chipName``` to specify on which chip you are asking for coordinates.  If you do not specify ```chipName```, the method will take your given (RA, Dec) positions, find the chips they land on, and return the pixel coordinates on those chips."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.coordUtils import pixelCoordsFromRaDec\n",
+    "\n",
+    "# first let's just calculate the pixel coordinates on the\n",
+    "# chips where the (RA, Dec) points naturally fall.\n",
+    "\n",
+    "xPix, yPix = pixelCoordsFromRaDec(np.array([121.0, 121.7, 124.0]),\n",
+    "                                 np.array([-35.2, -35.1, -34.0]),\n",
+    "                                 camera=camera, obs_metadata=obs)\n",
+    "\n",
+    "for xx, yy in zip(xPix, yPix):\n",
+    "    print(xx, yy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Now let us specify a specific chip.  In this case,\n",
+    "# pixelCoordsFromRaDec will return the pixel coordinates of\n",
+    "# each (RA, Dec) point as if it fell on the R:0,2 S:2,2 chip\n",
+    "\n",
+    "xPix, yPix = pixelCoordsFromRaDec(np.array([121.0, 121.7, 124.0]),\n",
+    "                                  np.array([-35.2, -35.1, -34.0]),\n",
+    "                                  chipName='R:0,2 S:2,2',\n",
+    "                                  camera=camera, obs_metadata=obs)\n",
+    "\n",
+    "for xx, yy in zip (xPix, yPix):\n",
+    "    print(xx, yy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Note that if you have already calculated the names of the chips on which your (RA, Dec) points fall, you can speed up ```pixelCoordsFromRaDec``` by passing those in as a kwarg (that way, ```pixelCoordsFromRaDec``` will not have to duplicate the call to ```chipNameFromRaDec``` that you already made)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "raList = np.array([121.0, 121.7, 124.0])\n",
+    "decList = np.array([-35.2, -35.1, -34.0])\n",
+    "\n",
+    "chipNameList = chipNameFromRaDec(raList, decList,\n",
+    "                                 camera=camera, obs_metadata=obs)\n",
+    "\n",
+    "xPix, yPix = pixelCoordsFromRaDec(raList, decList, chipName=chipNameList,\n",
+    "                                 camera=camera, obs_metadata=obs)\n",
+    "\n",
+    "for xx, yy in zip(xPix, yPix):\n",
+    "    print(xx, yy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finding the bounds of a chip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also methods to get the coordinate values (in pixels and in RA, Dec) of a specific chip.  These methods output lists of tuples in which each tuple represents the coordinates of one of the corners of the chip."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from lsst.sims.coordUtils import getCornerPixels, getCornerRaDec\n",
+    "\n",
+    "cpix = getCornerPixels('R:3,4 S:0,1', camera)\n",
+    "print('Corner pixels ',cpix,'\\n')\n",
+    "\n",
+    "cCoord = getCornerRaDec('R:3,4 S:0,1', camera, obs_metadata=obs)\n",
+    "print('Corner (RA, Dec) pairs: ',cCoord)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/examples/CameraUtilsExample.ipynb
+++ b/examples/CameraUtilsExample.ipynb
@@ -115,6 +115,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Note:</b> This cell will raise an ```ErfaWarning```.  This is harmless.  We are asking ```astropy.Time``` to convert between UTC (universal coordinate time) and TAI (international atomic time) in the future (when LSST goes on-sky), which is technically impossible, given that one cannot predict when leap seconds will be added."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -260,6 +267,13 @@
     "\n",
     "cCoord = getCornerRaDec('R:3,4 S:0,1', camera, obs_metadata=obs)\n",
     "print('Corner (RA, Dec) pairs: ',cCoord)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<b>Note:</b> Because of the rotation angle between the camera and the sky, the RA, Dec corner values will not be in any order relative to ```(min, max)```."
    ]
   },
   {

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -3,11 +3,36 @@ import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
 from lsst.sims.utils import _pupilCoordsFromRaDec, _raDecFromPupilCoords
 
-__all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
+__all__ = ["getCornerPixels",
+           "chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
            "pixelCoordsFromPupilCoords", "pixelCoordsFromRaDec", "_pixelCoordsFromRaDec",
            "focalPlaneCoordsFromPupilCoords", "focalPlaneCoordsFromRaDec", "_focalPlaneCoordsFromRaDec",
            "pupilCoordsFromPixelCoords",
            "raDecFromPixelCoords", "_raDecFromPixelCoords"]
+
+
+def getCornerPixels(detector_name, camera):
+    """
+    Return the pixel coordinates of the corners of a detector.
+
+    @param [in] detector_name is the name of the detector in question
+
+    @param [in] camera is the afwCameraGeom camera object containing
+    that detector
+
+    @para [out] a list of tuples representing the (x,y) pixel coordinates
+    of the corners of the detector.  Order will be
+
+    [(xmin, ymin), (xmin, ymax), (xmax, ymin), (xmax, ymax)]
+    """
+
+    det = camera[detector_name]
+    bbox = det.getBBox()
+    xmin = bbox.getMinX()
+    xmax = bbox.getMaxX()
+    ymin = bbox.getMinY()
+    ymax = bbox.getMaxY()
+    return [(xmin, ymin), (xmin, ymax), (xmax, ymin), (xmax, ymax)]
 
 
 def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -797,6 +797,7 @@ def focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=None):
 
         return np.array([xPix, yPix])
 
+    # if not are_arrays
     cp = camera.makeCameraPoint(afwGeom.Point2D(xPupil, yPupil), PUPIL)
     fpPoint = camera.transform(cp, FOCAL_PLANE).getPoint()
     return np.array([fpPoint.getX(), fpPoint.getY()])

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -268,9 +268,11 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
     Return the names of detectors that see the object specified by
     either (xPupil, yPupil).
 
-    @param [in] xPupil a numpy array of x pupil coordinates in radians
+    @param [in] xPupil is the x pupil coordinate in radians.
+    Can be either a float or a numpy array.
 
-    @param [in] yPupil a numpy array of y pupil coordinates in radians
+    @param [in] yPupil is the y pupil coordinate in radians.
+    Can be either a float or a numpy array.
 
     @param [in] allow_multiple_chips is a boolean (default False) indicating whether or not
     this method will allow objects to be visible on more than one chip.  If it is 'False'

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
 from lsst.sims.utils import _pupilCoordsFromRaDec, _raDecFromPupilCoords
@@ -71,10 +71,10 @@ def getCornerRaDec(detector_name, camera, obs_metadata, epoch=2000.0,
 
     cc = _getCornerRaDec(detector_name, camera, obs_metadata,
                          epoch=epoch, includeDistortion=includeDistortion)
-    return [(numpy.degrees(cc[0][0]), numpy.degrees(cc[0][1])),
-            (numpy.degrees(cc[1][0]), numpy.degrees(cc[1][1])),
-            (numpy.degrees(cc[2][0]), numpy.degrees(cc[2][1])),
-            (numpy.degrees(cc[3][0]), numpy.degrees(cc[3][1]))]
+    return [(np.degrees(cc[0][0]), np.degrees(cc[0][1])),
+            (np.degrees(cc[1][0]), np.degrees(cc[1][1])),
+            (np.degrees(cc[2][0]), np.degrees(cc[2][1])),
+            (np.degrees(cc[3][0]), np.degrees(cc[3][1]))]
 
 
 def _getCornerRaDec(detector_name, camera, obs_metadata,
@@ -113,8 +113,8 @@ def _getCornerRaDec(detector_name, camera, obs_metadata,
 
     cc_pix = getCornerPixels(detector_name, camera)
 
-    ra, dec = _raDecFromPixelCoords(numpy.array([cc[0] for cc in cc_pix]),
-                                    numpy.array([cc[1] for cc in cc_pix]),
+    ra, dec = _raDecFromPixelCoords(np.array([cc[0] for cc in cc_pix]),
+                                    np.array([cc[1] for cc in cc_pix]),
                                     [detector_name]*len(cc_pix),
                                     camera=camera, obs_metadata=obs_metadata,
                                     epoch=epoch, includeDistortion=True)
@@ -151,7 +151,7 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     @param [out] a numpy array of chip names
     """
 
-    return _chipNameFromRaDec(numpy.radians(ra), numpy.radians(dec),
+    return _chipNameFromRaDec(np.radians(ra), np.radians(dec),
                                   obs_metadata=obs_metadata, epoch=epoch,
                                   camera=camera, allow_multiple_chips=allow_multiple_chips)
 
@@ -184,7 +184,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     @param [out] a numpy array of chip names
     """
 
-    if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
+    if not isinstance(ra, np.ndarray) or not isinstance(dec, np.ndarray):
         raise RuntimeError("You need to pass numpy arrays of RA and Dec to chipName")
 
     if len(ra) != len(dec):
@@ -228,7 +228,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
 
     """
 
-    if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
+    if not isinstance(xPupil, np.ndarray) or not isinstance(yPupil, np.ndarray):
         raise RuntimeError("You need to pass numpy arrays of xPupil and yPupil to chipNameFromPupilCoords")
 
     if len(xPupil) != len(yPupil):
@@ -245,7 +245,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
     detList = camera.findDetectorsList(cameraPointList, PUPIL)
 
     for pt, det in zip(cameraPointList, detList):
-        if len(det)==0 or numpy.isnan(pt.getX()) or numpy.isnan(pt.getY()):
+        if len(det)==0 or np.isnan(pt.getX()) or np.isnan(pt.getY()):
             chipNames.append(None)
         else:
             names = [dd.getName() for dd in det]
@@ -261,7 +261,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
             else:
                 chipNames.append(names[0])
 
-    return numpy.array(chipNames)
+    return np.array(chipNames)
 
 
 def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
@@ -299,7 +299,7 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
     and the second row is the y pixel coordinate
     """
 
-    return _pixelCoordsFromRaDec(numpy.radians(ra), numpy.radians(dec),
+    return _pixelCoordsFromRaDec(np.radians(ra), np.radians(dec),
                                  chipNames=chipNames, camera=camera,
                                  includeDistortion=includeDistortion,
                                  obs_metadata=obs_metadata, epoch=epoch)
@@ -354,7 +354,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
         raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into " \
                            + "pixelCoordsFromRaDec")
 
-    if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
+    if not isinstance(ra, np.ndarray) or not isinstance(dec, np.ndarray):
         raise RuntimeError("You need to pass numpy arrays of RA and Dec to pixelCoordsFromRaDec")
 
     if len(ra) != len(dec):
@@ -406,7 +406,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     if not camera:
         raise RuntimeError("Camera not specified.  Cannot calculate pixel coordinates.")
 
-    if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
+    if not isinstance(xPupil, np.ndarray) or not isinstance(yPupil, np.ndarray):
         raise RuntimeError("You need to pass numpy arrays of xPupil and yPupil to pixelCoordsFromPupilCoords")
 
     if len(xPupil) != len(yPupil):
@@ -425,8 +425,8 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     yPix = []
     for name, x, y in zip(chipNames, xPupil, yPupil):
         if not name:
-            xPix.append(numpy.nan)
-            yPix.append(numpy.nan)
+            xPix.append(np.nan)
+            yPix.append(np.nan)
             continue
         cp = camera.makeCameraPoint(afwGeom.Point2D(x, y), PUPIL)
         det = camera[name]
@@ -434,7 +434,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
         detPoint = camera.transform(cp, cs)
         xPix.append(detPoint.getPoint().getX())
         yPix.append(detPoint.getPoint().getY())
-    return numpy.array([xPix, yPix])
+    return np.array([xPix, yPix])
 
 
 def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
@@ -485,18 +485,18 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
     for xPix, yPix, chipName in zip(xPixList, yPixList, chipNameList):
         if chipName is None or chipName=='None':
-            xPupilList.append(numpy.NaN)
-            yPupilList.append(numpy.NaN)
+            xPupilList.append(np.NaN)
+            yPupilList.append(np.NaN)
         else:
             pixPoint = camera.makeCameraPoint(afwGeom.Point2D(xPix, yPix), pixelSystemDict[chipName])
             pupilPoint =  camera.transform(pixPoint, pupilSystemDict[chipName]).getPoint()
             xPupilList.append(pupilPoint.getX())
             yPupilList.append(pupilPoint.getY())
 
-    xPupilList = numpy.array(xPupilList)
-    yPupilList = numpy.array(yPupilList)
+    xPupilList = np.array(xPupilList)
+    yPupilList = np.array(yPupilList)
 
-    return numpy.array([xPupilList, yPupilList])
+    return np.array([xPupilList, yPupilList])
 
 
 def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
@@ -531,7 +531,7 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
                                    camera=camera, obs_metadata=obs_metadata,
                                    epoch=epoch, includeDistortion=includeDistortion)
 
-    return numpy.degrees(output)
+    return np.degrees(output)
 
 
 def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
@@ -578,7 +578,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     if obs_metadata.rotSkyPos is None:
         raise RuntimeError("The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
 
-    if not isinstance(xPixList, numpy.ndarray) or not isinstance(yPixList, numpy.ndarray):
+    if not isinstance(xPixList, np.ndarray) or not isinstance(yPixList, np.ndarray):
         raise RuntimeError("You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
 
     if len(xPixList)!=len(yPixList):
@@ -598,7 +598,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     raOut, decOut = _raDecFromPupilCoords(xPupilList, yPupilList,
                                   obs_metadata=obs_metadata, epoch=epoch)
 
-    return numpy.array([raOut, decOut])
+    return np.array([raOut, decOut])
 
 
 def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None):
@@ -624,7 +624,7 @@ def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=Non
     coordinate (both in millimeters)
     """
 
-    return _focalPlaneCoordsFromRaDec(numpy.radians(ra), numpy.radians(dec),
+    return _focalPlaneCoordsFromRaDec(np.radians(ra), np.radians(dec),
                                       obs_metadata=obs_metadata, epoch=epoch,
                                       camera=camera)
 
@@ -652,7 +652,7 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=No
     coordinate (both in millimeters)
     """
 
-    if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
+    if not isinstance(ra, np.ndarray) or not isinstance(dec, np.ndarray):
         raise RuntimeError("You must pass numpy arrays of RA and Dec to focalPlaneCoordsFromRaDec")
 
     if len(ra) != len(dec):
@@ -698,7 +698,7 @@ def focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=None):
     coordinate (both in millimeters)
     """
 
-    if not isinstance(xPupil, numpy.ndarray) or not isinstance(yPupil, numpy.ndarray):
+    if not isinstance(xPupil, np.ndarray) or not isinstance(yPupil, np.ndarray):
         raise RuntimeError("You must pass numpy arrays of xPupil and yPupil to " +
                                "focalPlaneCoordsFromPupilCoords")
 
@@ -717,4 +717,4 @@ def focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=None):
         xPix.append(fpPoint.getPoint().getX())
         yPix.append(fpPoint.getPoint().getY())
 
-    return numpy.array([xPix, yPix])
+    return np.array([xPix, yPix])

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -56,7 +56,7 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
 
     if isinstance(chip_name, list) or isinstance(chip_name, np.ndarray):
         if len(chip_name) >1 and len(chip_name) != n_pts:
-            raise RuntimeError("You only passed %d chipNames to %s.\n" % (len(chip_name), method_name)
+            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_name), method_name)
                                + "You passed %d %s values." % (len(input_list[0]), input_names[0]))
 
         if len(chip_name)==1 and n_pts>1:
@@ -590,12 +590,16 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     """
     Convert pixel coordinates into RA, Dec
 
-    @param [in] xPixList is a numpy array of x pixel coordinates
+    @param [in] xPixList is the x pixel coordinate.  It can be either
+    a float or a numpy array.
 
-    @param [in] yPixList is a numpy array of y pixel coordinates
+    @param [in] yPixList is the y pixel coordinate.  It can be either
+    a float or a numpy array.
 
-    @param [in] chipNameList is a numpy array of chip names (corresponding to the points
-    in xPixList and yPixList)
+    @param [in] chipNameList is the name of the chip(s) on which the pixel coordinates
+    are defined.  This can be a list (in which case there should be one chip name
+    for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+    of the (xPix, yPix) points will be reckoned on that chip).
 
     @param [in] camera is an afw.CameraGeom.camera object defining the camera
 
@@ -626,12 +630,16 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     """
     Convert pixel coordinates into RA, Dec
 
-    @param [in] xPixList is a numpy array of x pixel coordinates
+    @param [in] xPixList is the x pixel coordinate.  It can be either
+    a float or a numpy array.
 
-    @param [in] yPixList is a numpy array of y pixel coordinates
+    @param [in] yPixList is the y pixel coordinate.  It can be either
+    a float or a numpy array.
 
-    @param [in] chipNameList is a numpy array of chip names (corresponding to the points
-    in xPixList and yPixList)
+    @param [in] chipNameList is the name of the chip(s) on which the pixel coordinates
+    are defined.  This can be a list (in which case there should be one chip name
+    for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+    of the (xPix, yPix) points will be reckoned on that chip).
 
     @param [in] camera is an afw.CameraGeom.camera object defining the camera
 
@@ -651,6 +659,13 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     Celestial Reference System)
     """
 
+    are_arrays, \
+    chipNameList = _validate_inputs_and_chipnames([xPixList, yPixList],
+                                                  ['xPixList', 'yPixList'],
+                                                  'raDecFromPixelCoords',
+                                                  chipNameList,
+                                                  chip_name_can_be_none=False)
+
     if camera is None:
         raise RuntimeError("You cannot call raDecFromPixelCoords without specifying a camera")
 
@@ -665,20 +680,6 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
     if obs_metadata.rotSkyPos is None:
         raise RuntimeError("The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
-
-    if not isinstance(xPixList, np.ndarray) or not isinstance(yPixList, np.ndarray):
-        raise RuntimeError("You must pass numpy arrays of xPix and yPix to raDecFromPixelCoords")
-
-    if len(xPixList)!=len(yPixList):
-        raise RuntimeError("You passed %d xPix coordinates but %d yPix coordinates " \
-                           % (len(xPixList), len(yPixList)) \
-                           +"to raDecFromPixelCoords")
-
-    if len(xPixList)!=len(chipNameList):
-        raise RuntimeError("You passed %d pixel coordinate pairs but %d chip names " \
-                          % (len(xPixList), len(chipNameList)) \
-                          +"to raDecFromPixelCoords")
-
 
     xPupilList, yPupilList = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList,
                                                         camera=camera, includeDistortion=includeDistortion)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -139,7 +139,10 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
             if len(names)>1 and not allow_multiple_chips:
                 raise RuntimeError("This method does not know how to deal with cameras " +
                                    "where points can be on multiple detectors.  " +
-                                   "Override CameraCoords.get_chipName to add this.")
+                                   "Override CameraCoords.get_chipName to add this.\n" +
+                                   "If you were only asking for the chip name (as opposed " +
+                                   "to pixel coordinates) you can try re-running with " +
+                                   "the kwarg allow_multiple_chips=True.")
             elif len(names)==0:
                 chipNames.append(None)
             else:

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -380,9 +380,13 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
 
     @param [in] yPupil a numpy array containing y pupil coordinates in radians
 
-    @param [in] chipNames a numpy array of chipNames.  If it is None, this method will call chipName
-    to find the array.  The option exists for the user to specify chipNames, just in case the user
-    has already called chipName for some reason.
+    @param [in] chipNames designates the names of the chips on which the pixel
+    coordinates will be reckoned.  Can be either single value, an array, or None.
+    If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+    If a single value, all of the pixel coordinates will be reckoned on the same
+    chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+    falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+    chip.  Default is None.
 
     @param [in] camera is an afwCameraGeom object specifying the attributes of the camera.
     This is an optional argument to be passed to chipName.
@@ -411,10 +415,21 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     if chipNames is None:
         chipNames = chipNameFromPupilCoords(xPupil, yPupil, camera=camera)
     else:
+        # check to see whether a list of chipNames was passed, or if only
+        # one chipName was passed
         if are_arrays:
-            if len(xPupil) != len(chipNames):
-                raise RuntimeError("You passed %d points but %d chipNames to pixelCoordsFromPupilCoords" %
-                                   (len(xPupil), len(chipNames)))
+            n_pts = len(xPupil)
+
+            if isinstance(chipNames, list) or isinstance(chipNames, np.ndarray):
+                if len(chipNames) == 1:
+                    chipNames = [chipNames[0]]*n_pts
+            else:
+                chipNames = [chipNames]*n_pts
+
+    if are_arrays:
+        if len(xPupil) != len(chipNames):
+            raise RuntimeError("You passed %d points but %d chipNames to pixelCoordsFromPupilCoords" %
+                               (len(xPupil), len(chipNames)))
 
     if are_arrays:
         xPix = []

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -437,9 +437,11 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     Get the pixel positions (or nan if not on a chip) for objects based
     on their pupil coordinates.
 
-    @param [in] xPupil a numpy array containing x pupil coordinates in radians
+    @param [in] xPupil is thex pupil coordinates in radians.
+    Can be either a float or a numpy array.
 
-    @param [in] yPupil a numpy array containing y pupil coordinates in radians
+    @param [in] yPupil is the y pupil coordinates in radians.
+    Can be either a float or a numpy array.
 
     @param [in] chipNames designates the names of the chips on which the pixel
     coordinates will be reckoned.  Can be either single value, an array, or None.

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -123,8 +123,8 @@ def _getCornerRaDec(detector_name, camera, obs_metadata,
 
 
 
-def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
-                           allow_multiple_chips=False):
+def chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
+                      epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
     either (xPupil, yPupil).
@@ -138,7 +138,7 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     @param [in] obs_metadata is an ObservationMetaData characterizing the telescope pointing
 
     @param [in] epoch is the epoch in Julian years of the equinox against which RA and Dec are
-    measured
+    measured.  Default is 2000.
 
     @param [in] camera is an afw.cameraGeom camera instance characterizing the camera
 
@@ -156,8 +156,8 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
                                   camera=camera, allow_multiple_chips=allow_multiple_chips)
 
 
-def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
-                           allow_multiple_chips=False):
+def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
+                       epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
     either (xPupil, yPupil).
@@ -171,7 +171,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     @param [in] obs_metadata is an ObservationMetaData characterizing the telescope pointing
 
     @param [in] epoch is the epoch in Julian years of the equinox against which RA and Dec are
-    measured
+    measured.  Default is 2000.
 
     @param [in] camera is an afw.cameraGeom camera instance characterizing the camera
 
@@ -264,8 +264,9 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
     return np.array(chipNames)
 
 
-def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
-                          chipNames=None, camera=None, includeDistortion=True):
+def pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
+                         chipNames=None, camera=None,
+                         epoch=2000.0, includeDistortion=True):
     """
     Get the pixel positions (or nan if not on a chip) for objects based
     on their RA, and Dec (in degrees)
@@ -280,7 +281,7 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
     pointing.
 
     @param [in] epoch is the epoch in Julian years of the equinox against which
-    RA is measured.
+    RA is measured.  Default is 2000.
 
     @param [in] chipNames a numpy array of chipNames.  If it is None, this method will call chipName
     to find the array.  The option exists for the user to specify chipNames, just in case the user
@@ -305,8 +306,9 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
                                  obs_metadata=obs_metadata, epoch=epoch)
 
 
-def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
-                          chipNames=None, camera=None, includeDistortion=True):
+def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
+                          chipNames=None, camera=None,
+                          epoch=2000.0, includeDistortion=True):
     """
     Get the pixel positions (or nan if not on a chip) for objects based
     on their RA, and Dec (in radians)
@@ -321,7 +323,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None,
     pointing.
 
     @param [in] epoch is the epoch in Julian years of the equinox against which
-    RA is measured.
+    RA is measured.  Default is 2000.
 
     @param [in] chipNames a numpy array of chipNames.  If it is None, this method will call chipName
     to find the array.  The option exists for the user to specify chipNames, just in case the user
@@ -500,7 +502,7 @@ def pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
 
 def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
-                         obs_metadata=None, epoch=None, includeDistortion=True):
+                         obs_metadata=None, epoch=2000.0, includeDistortion=True):
     """
     Convert pixel coordinates into RA, Dec
 
@@ -515,7 +517,8 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
     @param [in] obs_metadata is an ObservationMetaData defining the pointing
 
-    @param [in] epoch is the mean epoch in years of the celestial coordinate system
+    @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+    Default is 2000.
 
     @param [in] includeDistortion is a boolean.  If True (default), then this method will
     expect the true pixel coordinates with optical distortion included.  If False, this
@@ -535,7 +538,7 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
 
 def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
-                          obs_metadata=None, epoch=None, includeDistortion=True):
+                          obs_metadata=None, epoch=2000.0, includeDistortion=True):
     """
     Convert pixel coordinates into RA, Dec
 
@@ -550,7 +553,8 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
 
     @param [in] obs_metadata is an ObservationMetaData defining the pointing
 
-    @param [in] epoch is the mean epoch in years of the celestial coordinate system
+    @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+    Default is 2000.
 
     @param [in] includeDistortion is a boolean.  If True (default), then this method will
     expect the true pixel coordinates with optical distortion included.  If False, this
@@ -601,7 +605,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     return np.array([raOut, decOut])
 
 
-def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None):
+def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=2000.0, camera=None):
     """
     Get the focal plane coordinates for all objects in the catalog.
 
@@ -615,7 +619,7 @@ def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=Non
     pointing (only if specifying RA and Dec rather than pupil coordinates)
 
     @param [in] epoch is the julian epoch of the mean equinox used for coordinate transformations
-    (in years; only if specifying RA and Dec rather than pupil coordinates)
+    (in years; only if specifying RA and Dec rather than pupil coordinates; default is 2000)
 
     @param [in] camera is an afw.cameraGeom camera object
 
@@ -629,7 +633,7 @@ def focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=Non
                                       camera=camera)
 
 
-def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None):
+def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=2000.0, camera=None):
     """
     Get the focal plane coordinates for all objects in the catalog.
 
@@ -643,7 +647,7 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=No
     pointing (only if specifying RA and Dec rather than pupil coordinates)
 
     @param [in] epoch is the julian epoch of the mean equinox used for coordinate transformations
-    (in years; only if specifying RA and Dec rather than pupil coordinates)
+    (in years; only if specifying RA and Dec rather than pupil coordinates; default is 2000)
 
     @param [in] camera is an afw.cameraGeom camera object
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -13,7 +13,7 @@ __all__ = ["getCornerPixels", "_getCornerRaDec", "getCornerRaDec",
 
 
 def _validate_inputs_and_chipname(input_list, input_names, method_name,
-                                   chip_name, chipname_can_be_none = True):
+                                  chip_name, chipname_can_be_none = True):
     """
     This will wrap _validate_inputs, but also reformat chip_name if necessary.
 
@@ -55,11 +55,11 @@ def _validate_inputs_and_chipname(input_list, input_names, method_name,
         n_pts = 1
 
     if isinstance(chip_name, list) or isinstance(chip_name, np.ndarray):
-        if len(chip_name) >1 and len(chip_name) != n_pts:
-            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_name), method_name)
-                               + "You passed %d %s values." % (len(input_list[0]), input_names[0]))
+        if len(chip_name) > 1 and len(chip_name) != n_pts:
+            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_name), method_name) +
+                               "You passed %d %s values." % (len(input_list[0]), input_names[0]))
 
-        if len(chip_name)==1 and n_pts>1:
+        if len(chip_name) == 1 and n_pts > 1:
             chip_name_out = [chip_name[0]]*n_pts
         else:
             chip_name_out = chip_name
@@ -183,7 +183,6 @@ def _getCornerRaDec(detector_name, camera, obs_metadata,
     return [(ra[0], dec[0]), (ra[1], dec[1]), (ra[2], dec[2]), (ra[3], dec[3])]
 
 
-
 def chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
                       epoch=2000.0, allow_multiple_chips=False):
     """
@@ -213,8 +212,8 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
     """
 
     return _chipNameFromRaDec(np.radians(ra), np.radians(dec),
-                                  obs_metadata=obs_metadata, epoch=epoch,
-                                  camera=camera, allow_multiple_chips=allow_multiple_chips)
+                              obs_metadata=obs_metadata, epoch=epoch,
+                              camera=camera, allow_multiple_chips=allow_multiple_chips)
 
 
 def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
@@ -245,7 +244,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
     @param [out] a numpy array of chip names
     """
 
-    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "chipNameFromRaDec")
+    _validate_inputs([ra, dec], ['ra', 'dec'], "chipNameFromRaDec")
 
     if epoch is None:
         raise RuntimeError("You need to pass an epoch into chipName")
@@ -294,25 +293,25 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
     chipNames = []
 
     if are_arrays:
-        cameraPointList = [afwGeom.Point2D(x,y) for x,y in zip(xPupil, yPupil)]
+        cameraPointList = [afwGeom.Point2D(x, y) for x, y in zip(xPupil, yPupil)]
     else:
         cameraPointList = [afwGeom.Point2D(xPupil, yPupil)]
 
     detList = camera.findDetectorsList(cameraPointList, PUPIL)
 
     for pt, det in zip(cameraPointList, detList):
-        if len(det)==0 or np.isnan(pt.getX()) or np.isnan(pt.getY()):
+        if len(det) == 0 or np.isnan(pt.getX()) or np.isnan(pt.getY()):
             chipNames.append(None)
         else:
             names = [dd.getName() for dd in det]
-            if len(names)>1 and not allow_multiple_chips:
+            if len(names) > 1 and not allow_multiple_chips:
                 raise RuntimeError("This method does not know how to deal with cameras " +
                                    "where points can be on multiple detectors.  " +
                                    "Override CameraCoords.get_chipName to add this.\n" +
                                    "If you were only asking for the chip name (as opposed " +
                                    "to pixel coordinates) you can try re-running with " +
                                    "the kwarg allow_multiple_chips=True.")
-            elif len(names)==0:
+            elif len(names) == 0:
                 chipNames.append(None)
             else:
                 chipNames.append(names[0])
@@ -412,7 +411,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
     are_arrays, \
     chipNameList = _validate_inputs_and_chipname([ra, dec], ['ra', 'dec'],
                                                  'pixelCoordsFromRaDec',
-                                                  chipName)
+                                                 chipName)
 
     if epoch is None:
         raise RuntimeError("You need to pass an epoch into pixelCoordsFromRaDec")
@@ -421,12 +420,12 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
         raise RuntimeError("You need to pass an ObservationMetaData into pixelCoordsFromRaDec")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into " \
-                           + "pixelCoordsFromRaDec")
+        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into "
+                           "pixelCoordsFromRaDec")
 
     if obs_metadata.rotSkyPos is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into " \
-                           + "pixelCoordsFromRaDec")
+        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into "
+                           "pixelCoordsFromRaDec")
 
     xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
     return pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipNameList, camera=camera,
@@ -468,8 +467,8 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
 
     are_arrays, \
     chipNameList = _validate_inputs_and_chipname([xPupil, yPupil], ["xPupil", "yPupil"],
-                                                  "pixelCoordsFromPupilCoords",
-                                                  chipName)
+                                                 "pixelCoordsFromPupilCoords",
+                                                 chipName)
     if includeDistortion:
         pixelType = PIXELS
     else:
@@ -543,9 +542,9 @@ def pupilCoordsFromPixelCoords(xPix, yPix, chipName, camera=None,
 
     are_arrays, \
     chipNameList = _validate_inputs_and_chipname([xPix, yPix], ['xPix', 'yPix'],
-                                                  "pupilCoordsFromPixelCoords",
-                                                  chipName,
-                                                  chipname_can_be_none=False)
+                                                 "pupilCoordsFromPixelCoords",
+                                                 chipName,
+                                                 chipname_can_be_none=False)
 
     if includeDistortion:
         pixelType = PIXELS
@@ -554,24 +553,22 @@ def pupilCoordsFromPixelCoords(xPix, yPix, chipName, camera=None,
 
     pixelSystemDict = {}
     pupilSystemDict = {}
-    detectorDict = {}
     for name in chipNameList:
-        if name not in pixelSystemDict and name is not None and name!='None':
+        if name not in pixelSystemDict and name is not None and name != 'None':
                 pixelSystemDict[name] = camera[name].makeCameraSys(pixelType)
                 pupilSystemDict[name] = camera[name].makeCameraSys(PUPIL)
-
 
     if are_arrays:
         xPupilList = []
         yPupilList = []
 
         for xx, yy, name in zip(xPix, yPix, chipNameList):
-            if name is None or name=='None':
+            if name is None or name == 'None':
                 xPupilList.append(np.NaN)
                 yPupilList.append(np.NaN)
             else:
                 pixPoint = camera.makeCameraPoint(afwGeom.Point2D(xx, yy), pixelSystemDict[name])
-                pupilPoint =  camera.transform(pixPoint, pupilSystemDict[name]).getPoint()
+                pupilPoint = camera.transform(pixPoint, pupilSystemDict[name]).getPoint()
                 xPupilList.append(pupilPoint.getX())
                 yPupilList.append(pupilPoint.getY())
 
@@ -665,10 +662,10 @@ def _raDecFromPixelCoords(xPix, yPix, chipName, camera=None,
 
     are_arrays, \
     chipNameList = _validate_inputs_and_chipname([xPix, yPix],
-                                                  ['xPix', 'yPix'],
-                                                  'raDecFromPixelCoords',
-                                                  chipName,
-                                                  chipname_can_be_none=False)
+                                                 ['xPix', 'yPix'],
+                                                 'raDecFromPixelCoords',
+                                                 chipName,
+                                                 chipname_can_be_none=False)
 
     if camera is None:
         raise RuntimeError("You cannot call raDecFromPixelCoords without specifying a camera")
@@ -689,7 +686,7 @@ def _raDecFromPixelCoords(xPix, yPix, chipName, camera=None,
                                                         camera=camera, includeDistortion=includeDistortion)
 
     raOut, decOut = _raDecFromPupilCoords(xPupilList, yPupilList,
-                                  obs_metadata=obs_metadata, epoch=epoch)
+                                          obs_metadata=obs_metadata, epoch=epoch)
 
     return np.array([raOut, decOut])
 
@@ -745,28 +742,26 @@ def _focalPlaneCoordsFromRaDec(ra, dec, obs_metadata=None, epoch=2000.0, camera=
     coordinate (both in millimeters)
     """
 
-    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], 'focalPlaneCoordsFromRaDec')
+    _validate_inputs([ra, dec], ['ra', 'dec'], 'focalPlaneCoordsFromRaDec')
 
     if epoch is None:
-        raise RuntimeError("You have to specify an epoch to run " + \
-                            "focalPlaneCoordsFromRaDec")
+        raise RuntimeError("You have to specify an epoch to run "
+                           "focalPlaneCoordsFromRaDec")
 
     if obs_metadata is None:
-        raise RuntimeError("You have to specify an ObservationMetaData to run " + \
-                               "focalPlaneCoordsFromRaDec")
-
+        raise RuntimeError("You have to specify an ObservationMetaData to run "
+                           "focalPlaneCoordsFromRaDec")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with an " \
-                           + "mjd into focalPlaneCoordsFromRaDec")
+        raise RuntimeError("You need to pass an ObservationMetaData with an "
+                           "mjd into focalPlaneCoordsFromRaDec")
 
     if obs_metadata.rotSkyPos is None:
-        raise RuntimeError("You need to pass an ObservationMetaData with a " \
-                           + "rotSkyPos into focalPlaneCoordsFromRaDec")
-
+        raise RuntimeError("You need to pass an ObservationMetaData with a "
+                           "rotSkyPos into focalPlaneCoordsFromRaDec")
 
     xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata,
-                                                epoch=epoch)
+                                           epoch=epoch)
 
     return focalPlaneCoordsFromPupilCoords(xPupil, yPupil, camera=camera)
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -33,7 +33,7 @@ def _validate_inputs_and_chipname(input_list, input_names, method_name,
 
     1) the contents of input_list are not all of the same type
     2) the contents of input_list are not all floats or numpy arrays
-    3) the contnets of input_list are different lengths (if numpy arrays)
+    3) the contents of input_list are different lengths (if numpy arrays)
     4) chip_name is None and chipname_can_be_none is False
     5) chip_name is a list or array of different length than input_list[0]
        (if input_list[0] is a list or array) and len(chip_name)>1

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -435,7 +435,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
     Get the pixel positions (or nan if not on a chip) for objects based
     on their pupil coordinates.
 
-    @param [in] xPupil is thex pupil coordinates in radians.
+    @param [in] xPupil is the x pupil coordinates in radians.
     Can be either a float or a numpy array.
 
     @param [in] yPupil is the y pupil coordinates in radians.

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -132,10 +132,7 @@ def getCornerRaDec(detector_name, camera, obs_metadata, epoch=2000.0,
 
     cc = _getCornerRaDec(detector_name, camera, obs_metadata,
                          epoch=epoch, includeDistortion=includeDistortion)
-    return [(np.degrees(cc[0][0]), np.degrees(cc[0][1])),
-            (np.degrees(cc[1][0]), np.degrees(cc[1][1])),
-            (np.degrees(cc[2][0]), np.degrees(cc[2][1])),
-            (np.degrees(cc[3][0]), np.degrees(cc[3][1]))]
+    return [tuple(np.degrees(row)) for row in cc]
 
 
 def _getCornerRaDec(detector_name, camera, obs_metadata,

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -13,7 +13,7 @@ __all__ = ["getCornerPixels", "_getCornerRaDec", "getCornerRaDec",
 
 
 def _validate_inputs_and_chipnames(input_list, input_names, method_name,
-                                   chip_name, chipnames_can_be_none = True):
+                                   chip_names, chipnames_can_be_none = True):
     """
     This will wrap _validate_inputs, but also reformat chip_name if necessary.
 
@@ -24,7 +24,7 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
 
     method_name is the name of the method whose input is being validated.
 
-    chip_name is the chip_name variable passed into the calling method.
+    chip_names is the chip_name variable passed into the calling method.
 
     chipnames_can_be_none is a boolean that controls whether or not
     chip_name is allowed to be None.
@@ -39,14 +39,14 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
        (if input_list[0] is a list or array) and len(chip_name)>1
 
     This method returns a boolean indicating whether input_list[0]
-    is a numpy array and a re-casting of chip_name as a list
-    of length equal to input_list[0] (unless chip_name is None;
-    then it will leave chip_name untouched)
+    is a numpy array and a re-casting of chip_names as a list
+    of length equal to input_list[0] (unless chip_names is None;
+    then it will leave chip_names untouched)
     """
 
     are_arrays = _validate_inputs(input_list, input_names, method_name)
 
-    if chip_name is None and not chipnames_can_be_none:
+    if chip_names is None and not chipnames_can_be_none:
         raise RuntimeError("You passed chipName=None to %s" % method_name)
 
     if are_arrays:
@@ -54,22 +54,22 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
     else:
         n_pts = 1
 
-    if isinstance(chip_name, list) or isinstance(chip_name, np.ndarray):
-        if len(chip_name) >1 and len(chip_name) != n_pts:
-            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_name), method_name)
+    if isinstance(chip_names, list) or isinstance(chip_names, np.ndarray):
+        if len(chip_names) >1 and len(chip_names) != n_pts:
+            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_names), method_name)
                                + "You passed %d %s values." % (len(input_list[0]), input_names[0]))
 
-        if len(chip_name)==1 and n_pts>1:
-            chip_name_out = [chip_name[0]]*n_pts
+        if len(chip_names)==1 and n_pts>1:
+            chip_names_out = [chip_names[0]]*n_pts
         else:
-            chip_name_out = chip_name
+            chip_names_out = chip_names
 
-        return are_arrays, chip_name_out
+        return are_arrays, chip_names_out
 
-    elif chip_name is None:
-        return are_arrays, chip_name
+    elif chip_names is None:
+        return are_arrays, chip_names
     else:
-        return are_arrays, [chip_name]*n_pts
+        return are_arrays, [chip_names]*n_pts
 
 
 def getCornerPixels(detector_name, camera):

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -1,7 +1,6 @@
 import numpy
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
-from lsst.afw.cameraGeom import SCIENCE
 from lsst.sims.utils import _pupilCoordsFromRaDec, _raDecFromPupilCoords
 
 __all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
@@ -14,9 +13,8 @@ __all__ = ["chipNameFromPupilCoords", "chipNameFromRaDec", "_chipNameFromRaDec",
 def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
                            allow_multiple_chips=False):
     """
-    Return the names of science detectors that see the object specified by
-    either (xPupil, yPupil).  Note: this method does not return
-    the name of guide, focus, or wavefront detectors.
+    Return the names of detectors that see the object specified by
+    either (xPupil, yPupil).
 
     @param [in] ra in degrees (a numpy array).
     In the International Celestial Reference System.
@@ -37,7 +35,7 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     and an object falls on more than one chip, it will still only return the first chip in the
     list of chips returned. THIS BEHAVIOR SHOULD BE FIXED IN A FUTURE TICKET.
 
-    @param [out] a numpy array of chip names (science detectors only)
+    @param [out] a numpy array of chip names
     """
 
     return _chipNameFromRaDec(numpy.radians(ra), numpy.radians(dec),
@@ -48,9 +46,8 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
 def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
                            allow_multiple_chips=False):
     """
-    Return the names of science detectors that see the object specified by
-    either (xPupil, yPupil).  Note: this method does not return
-    the name of guide, focus, or wavefront detectors.
+    Return the names of detectors that see the object specified by
+    either (xPupil, yPupil).
 
     @param [in] ra in radians (a numpy array).
     In the International Celestial Reference System.
@@ -71,7 +68,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
     and an object falls on more than one chip, it will still only return the first chip in the
     list of chips returned. THIS BEHAVIOR SHOULD BE FIXED IN A FUTURE TICKET.
 
-    @param [out] a numpy array of chip names (science detectors only)
+    @param [out] a numpy array of chip names
     """
 
     if not isinstance(ra, numpy.ndarray) or not isinstance(dec, numpy.ndarray):
@@ -99,9 +96,8 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, epoch=None, camera=None,
 
 def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=False):
     """
-    Return the names of science detectors that see the object specified by
-    either (xPupil, yPupil).  Note: this method does not return
-    the name of guide, focus, or wavefront detectors.
+    Return the names of detectors that see the object specified by
+    either (xPupil, yPupil).
 
     @param [in] xPupil a numpy array of x pupil coordinates in radians
 
@@ -115,7 +111,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
 
     @param [in] camera is an afwCameraGeom object that specifies the attributes of the camera.
 
-    @param [out] a numpy array of chip names (science detectors only)
+    @param [out] a numpy array of chip names
 
     """
 
@@ -139,7 +135,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
         if len(det)==0 or numpy.isnan(pt.getX()) or numpy.isnan(pt.getY()):
             chipNames.append(None)
         else:
-            names = [dd.getName() for dd in det if dd.getType()==SCIENCE]
+            names = [dd.getName() for dd in det]
             if len(names)>1 and not allow_multiple_chips:
                 raise RuntimeError("This method does not know how to deal with cameras " +
                                    "where points can be on multiple detectors.  " +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -12,8 +12,8 @@ __all__ = ["getCornerPixels", "_getCornerRaDec", "getCornerRaDec",
            "raDecFromPixelCoords", "_raDecFromPixelCoords"]
 
 
-def _validate_inputs_and_chipnames(input_list, input_names, method_name,
-                                   chip_names, chipnames_can_be_none = True):
+def _validate_inputs_and_chipname(input_list, input_names, method_name,
+                                   chip_name, chipname_can_be_none = True):
     """
     This will wrap _validate_inputs, but also reformat chip_name if necessary.
 
@@ -24,9 +24,9 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
 
     method_name is the name of the method whose input is being validated.
 
-    chip_names is the chip_name variable passed into the calling method.
+    chip_name is the chip_name variable passed into the calling method.
 
-    chipnames_can_be_none is a boolean that controls whether or not
+    chipname_can_be_none is a boolean that controls whether or not
     chip_name is allowed to be None.
 
     This method will raise a RuntimeError if:
@@ -34,19 +34,19 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
     1) the contents of input_list are not all of the same type
     2) the contents of input_list are not all floats or numpy arrays
     3) the contnets of input_list are different lengths (if numpy arrays)
-    4) chip_name is None and chipnames_can_be_none is False
+    4) chip_name is None and chipname_can_be_none is False
     5) chip_name is a list or array of different length than input_list[0]
        (if input_list[0] is a list or array) and len(chip_name)>1
 
     This method returns a boolean indicating whether input_list[0]
-    is a numpy array and a re-casting of chip_names as a list
-    of length equal to input_list[0] (unless chip_names is None;
-    then it will leave chip_names untouched)
+    is a numpy array and a re-casting of chip_name as a list
+    of length equal to input_list[0] (unless chip_name is None;
+    then it will leave chip_name untouched)
     """
 
     are_arrays = _validate_inputs(input_list, input_names, method_name)
 
-    if chip_names is None and not chipnames_can_be_none:
+    if chip_name is None and not chipname_can_be_none:
         raise RuntimeError("You passed chipName=None to %s" % method_name)
 
     if are_arrays:
@@ -54,22 +54,22 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
     else:
         n_pts = 1
 
-    if isinstance(chip_names, list) or isinstance(chip_names, np.ndarray):
-        if len(chip_names) >1 and len(chip_names) != n_pts:
-            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_names), method_name)
+    if isinstance(chip_name, list) or isinstance(chip_name, np.ndarray):
+        if len(chip_name) >1 and len(chip_name) != n_pts:
+            raise RuntimeError("You passed %d chipNames to %s.\n" % (len(chip_name), method_name)
                                + "You passed %d %s values." % (len(input_list[0]), input_names[0]))
 
-        if len(chip_names)==1 and n_pts>1:
-            chip_names_out = [chip_names[0]]*n_pts
+        if len(chip_name)==1 and n_pts>1:
+            chip_name_out = [chip_name[0]]*n_pts
         else:
-            chip_names_out = chip_names
+            chip_name_out = chip_name
 
-        return are_arrays, chip_names_out
+        return are_arrays, chip_name_out
 
-    elif chip_names is None:
-        return are_arrays, chip_names
+    elif chip_name is None:
+        return are_arrays, chip_name
     else:
-        return are_arrays, [chip_names]*n_pts
+        return are_arrays, [chip_name]*n_pts
 
 
 def getCornerPixels(detector_name, camera):
@@ -324,7 +324,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
 
 
 def pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
-                         chipNames=None, camera=None,
+                         chipName=None, camera=None,
                          epoch=2000.0, includeDistortion=True):
     """
     Get the pixel positions (or nan if not on a chip) for objects based
@@ -342,7 +342,7 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
     @param [in] epoch is the epoch in Julian years of the equinox against which
     RA is measured.  Default is 2000.
 
-    @param [in] chipNames designates the names of the chips on which the pixel
+    @param [in] chipName designates the names of the chips on which the pixel
     coordinates will be reckoned.  Can be either single value, an array, or None.
     If an array, there must be as many chipNames as there are (RA, Dec) pairs.
     If a single value, all of the pixel coordinates will be reckoned on the same
@@ -364,13 +364,13 @@ def pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
     """
 
     return _pixelCoordsFromRaDec(np.radians(ra), np.radians(dec),
-                                 chipNames=chipNames, camera=camera,
+                                 chipName=chipName, camera=camera,
                                  includeDistortion=includeDistortion,
                                  obs_metadata=obs_metadata, epoch=epoch)
 
 
 def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
-                          chipNames=None, camera=None,
+                          chipName=None, camera=None,
                           epoch=2000.0, includeDistortion=True):
     """
     Get the pixel positions (or nan if not on a chip) for objects based
@@ -388,7 +388,7 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
     @param [in] epoch is the epoch in Julian years of the equinox against which
     RA is measured.  Default is 2000.
 
-    @param [in] chipNames designates the names of the chips on which the pixel
+    @param [in] chipName designates the names of the chips on which the pixel
     coordinates will be reckoned.  Can be either single value, an array, or None.
     If an array, there must be as many chipNames as there are (RA, Dec) pairs.
     If a single value, all of the pixel coordinates will be reckoned on the same
@@ -410,9 +410,9 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
     """
 
     are_arrays, \
-    chipNameList = _validate_inputs_and_chipnames([ra, dec], ['ra', 'dec'],
+    chipNameList = _validate_inputs_and_chipname([ra, dec], ['ra', 'dec'],
                                                  'pixelCoordsFromRaDec',
-                                                              chipNames)
+                                                  chipName)
 
     if epoch is None:
         raise RuntimeError("You need to pass an epoch into pixelCoordsFromRaDec")
@@ -429,11 +429,11 @@ def _pixelCoordsFromRaDec(ra, dec, obs_metadata=None,
                            + "pixelCoordsFromRaDec")
 
     xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
-    return pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=chipNameList, camera=camera,
+    return pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipNameList, camera=camera,
                                       includeDistortion=includeDistortion)
 
 
-def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
+def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
                                camera=None, includeDistortion=True):
     """
     Get the pixel positions (or nan if not on a chip) for objects based
@@ -445,7 +445,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     @param [in] yPupil is the y pupil coordinates in radians.
     Can be either a float or a numpy array.
 
-    @param [in] chipNames designates the names of the chips on which the pixel
+    @param [in] chipName designates the names of the chips on which the pixel
     coordinates will be reckoned.  Can be either single value, an array, or None.
     If an array, there must be as many chipNames as there are (RA, Dec) pairs.
     If a single value, all of the pixel coordinates will be reckoned on the same
@@ -467,9 +467,9 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipNames=None,
     """
 
     are_arrays, \
-    chipNameList = _validate_inputs_and_chipnames([xPupil, yPupil], ["xPupil", "yPupil"],
+    chipNameList = _validate_inputs_and_chipname([xPupil, yPupil], ["xPupil", "yPupil"],
                                                   "pixelCoordsFromPupilCoords",
-                                                  chipNames)
+                                                  chipName)
     if includeDistortion:
         pixelType = PIXELS
     else:
@@ -542,10 +542,10 @@ def pupilCoordsFromPixelCoords(xPix, yPix, chipName, camera=None,
         raise RuntimeError("You cannot call pupilCoordsFromPixelCoords without specifying a camera")
 
     are_arrays, \
-    chipNameList = _validate_inputs_and_chipnames([xPix, yPix], ['xPix', 'yPix'],
+    chipNameList = _validate_inputs_and_chipname([xPix, yPix], ['xPix', 'yPix'],
                                                   "pupilCoordsFromPixelCoords",
                                                   chipName,
-                                                  chipnames_can_be_none=False)
+                                                  chipname_can_be_none=False)
 
     if includeDistortion:
         pixelType = PIXELS
@@ -589,18 +589,18 @@ def pupilCoordsFromPixelCoords(xPix, yPix, chipName, camera=None,
     return np.array([pupilPoint.getX(), pupilPoint.getY()])
 
 
-def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
+def raDecFromPixelCoords(xPix, yPix, chipName, camera=None,
                          obs_metadata=None, epoch=2000.0, includeDistortion=True):
     """
     Convert pixel coordinates into RA, Dec
 
-    @param [in] xPixList is the x pixel coordinate.  It can be either
+    @param [in] xPix is the x pixel coordinate.  It can be either
     a float or a numpy array.
 
-    @param [in] yPixList is the y pixel coordinate.  It can be either
+    @param [in] yPix is the y pixel coordinate.  It can be either
     a float or a numpy array.
 
-    @param [in] chipNameList is the name of the chip(s) on which the pixel coordinates
+    @param [in] chipName is the name of the chip(s) on which the pixel coordinates
     are defined.  This can be a list (in which case there should be one chip name
     for each (xPix, yPix) coordinate pair), or a single value (in which case, all
     of the (xPix, yPix) points will be reckoned on that chip).
@@ -622,25 +622,25 @@ def raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     and the second row is the Dec coordinate (both in degrees; in the
     International Celestial Reference System)
     """
-    output = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
+    output = _raDecFromPixelCoords(xPix, yPix, chipName,
                                    camera=camera, obs_metadata=obs_metadata,
                                    epoch=epoch, includeDistortion=includeDistortion)
 
     return np.degrees(output)
 
 
-def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
+def _raDecFromPixelCoords(xPix, yPix, chipName, camera=None,
                           obs_metadata=None, epoch=2000.0, includeDistortion=True):
     """
     Convert pixel coordinates into RA, Dec
 
-    @param [in] xPixList is the x pixel coordinate.  It can be either
+    @param [in] xPix is the x pixel coordinate.  It can be either
     a float or a numpy array.
 
-    @param [in] yPixList is the y pixel coordinate.  It can be either
+    @param [in] yPix is the y pixel coordinate.  It can be either
     a float or a numpy array.
 
-    @param [in] chipNameList is the name of the chip(s) on which the pixel coordinates
+    @param [in] chipName is the name of the chip(s) on which the pixel coordinates
     are defined.  This can be a list (in which case there should be one chip name
     for each (xPix, yPix) coordinate pair), or a single value (in which case, all
     of the (xPix, yPix) points will be reckoned on that chip).
@@ -664,11 +664,11 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     """
 
     are_arrays, \
-    chipNameList = _validate_inputs_and_chipnames([xPixList, yPixList],
-                                                  ['xPixList', 'yPixList'],
+    chipNameList = _validate_inputs_and_chipname([xPix, yPix],
+                                                  ['xPix', 'yPix'],
                                                   'raDecFromPixelCoords',
-                                                  chipNameList,
-                                                  chipnames_can_be_none=False)
+                                                  chipName,
+                                                  chipname_can_be_none=False)
 
     if camera is None:
         raise RuntimeError("You cannot call raDecFromPixelCoords without specifying a camera")
@@ -685,7 +685,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
     if obs_metadata.rotSkyPos is None:
         raise RuntimeError("The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
 
-    xPupilList, yPupilList = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList,
+    xPupilList, yPupilList = pupilCoordsFromPixelCoords(xPix, yPix, chipNameList,
                                                         camera=camera, includeDistortion=includeDistortion)
 
     raOut, decOut = _raDecFromPupilCoords(xPupilList, yPupilList,

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -13,7 +13,7 @@ __all__ = ["getCornerPixels", "_getCornerRaDec", "getCornerRaDec",
 
 
 def _validate_inputs_and_chipnames(input_list, input_names, method_name,
-                                   chip_name, chip_name_can_be_none = True):
+                                   chip_name, chipnames_can_be_none = True):
     """
     This will wrap _validate_inputs, but also reformat chip_name if necessary.
 
@@ -26,7 +26,7 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
 
     chip_name is the chip_name variable passed into the calling method.
 
-    chip_name_can_be_none is a boolean that controls whether or not
+    chipnames_can_be_none is a boolean that controls whether or not
     chip_name is allowed to be None.
 
     This method will raise a RuntimeError if:
@@ -34,7 +34,7 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
     1) the contents of input_list are not all of the same type
     2) the contents of input_list are not all floats or numpy arrays
     3) the contnets of input_list are different lengths (if numpy arrays)
-    4) chip_name is None and chip_name_can_be_none is False
+    4) chip_name is None and chipnames_can_be_none is False
     5) chip_name is a list or array of different length than input_list[0]
        (if input_list[0] is a list or array) and len(chip_name)>1
 
@@ -46,7 +46,7 @@ def _validate_inputs_and_chipnames(input_list, input_names, method_name,
 
     are_arrays = _validate_inputs(input_list, input_names, method_name)
 
-    if chip_name is None and not chip_name_can_be_none:
+    if chip_name is None and not chipnames_can_be_none:
         raise RuntimeError("You passed chipName=None to %s" % method_name)
 
     if are_arrays:
@@ -543,7 +543,7 @@ def pupilCoordsFromPixelCoords(xPix, yPix, chipName, camera=None,
     chipNameList = _validate_inputs_and_chipnames([xPix, yPix], ['xPix', 'yPix'],
                                                   "pupilCoordsFromPixelCoords",
                                                   chipName,
-                                                  chip_name_can_be_none=False)
+                                                  chipnames_can_be_none=False)
 
     if includeDistortion:
         pixelType = PIXELS
@@ -666,7 +666,7 @@ def _raDecFromPixelCoords(xPixList, yPixList, chipNameList, camera=None,
                                                   ['xPixList', 'yPixList'],
                                                   'raDecFromPixelCoords',
                                                   chipNameList,
-                                                  chip_name_can_be_none=False)
+                                                  chipnames_can_be_none=False)
 
     if camera is None:
         raise RuntimeError("You cannot call raDecFromPixelCoords without specifying a camera")

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -345,18 +345,18 @@ class PixelCoordTest(unittest.TestCase):
             xx3, yy3 = pixelCoordsFromPupilCoords(xpList, ypList, camera=self.camera,
                                                   includeDistortion=includeDistortion)
 
-            xx4, yy4 = pixelCoordsFromPupilCoords(xpList, ypList, chipNames=chipNameList,
+            xx4, yy4 = pixelCoordsFromPupilCoords(xpList, ypList, chipName=chipNameList,
                                                   camera=self.camera,
                                                   includeDistortion=includeDistortion)
 
             xx5, yy5 = pixelCoordsFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
                                             camera=self.camera, includeDistortion=includeDistortion,
-                                            chipNames=chipNameList)
+                                            chipName=chipNameList)
 
             xx6, yy6 = _pixelCoordsFromRaDec(np.radians(raList), np.radians(decList),
                                              obs_metadata=obs, epoch=2000.0,
                                              camera=self.camera, includeDistortion=includeDistortion,
-                                             chipNames=chipNameList)
+                                             chipName=chipNameList)
 
 
             np.testing.assert_array_equal(xx1, xx2)
@@ -405,7 +405,7 @@ class PixelCoordTest(unittest.TestCase):
                 x_f, y_f = pixelCoordsFromRaDec(raList[ix], decList[ix], obs_metadata=obs,
                                                 epoch=2000.0, camera=self.camera,
                                                 includeDistortion=includeDistortion,
-                                                chipNames=chipNameList[ix])
+                                                chipName=chipNameList[ix])
                 self.assertIsInstance(x_f, np.float)
                 self.assertIsInstance(y_f, np.float)
                 if not np.isnan(x_f):
@@ -418,7 +418,7 @@ class PixelCoordTest(unittest.TestCase):
                 x_f, y_f = pixelCoordsFromRaDec(raList[ix], decList[ix], obs_metadata=obs,
                                                 epoch=2000.0, camera=self.camera,
                                                 includeDistortion=includeDistortion,
-                                                chipNames=[chipNameList[ix]])
+                                                chipName=[chipNameList[ix]])
                 self.assertIsInstance(x_f, np.float)
                 self.assertIsInstance(y_f, np.float)
                 if not np.isnan(x_f):
@@ -460,7 +460,7 @@ class PixelCoordTest(unittest.TestCase):
                                                   obs_metadata=obs,
                                                   includeDistortion=True,
                                                   camera=self.camera,
-                                                  chipNames=chosen_chip)
+                                                  chipName=chosen_chip)
 
         np.testing.assert_array_almost_equal(xPixControl, xPixTest, 12)
         np.testing.assert_array_almost_equal(yPixControl, yPixTest, 12)
@@ -469,7 +469,7 @@ class PixelCoordTest(unittest.TestCase):
                                                   obs_metadata=obs,
                                                   includeDistortion=True,
                                                   camera=self.camera,
-                                                  chipNames=[chosen_chip])
+                                                  chipName=[chosen_chip])
 
         np.testing.assert_array_almost_equal(xPixControl, xPixTest, 12)
         np.testing.assert_array_almost_equal(yPixControl, yPixTest, 12)
@@ -601,12 +601,12 @@ class PixelCoordTest(unittest.TestCase):
         # test that an error is raised if you pass an incorrect
         # number of chipNames to pixelCoordsFromPupilCoords
         with self.assertRaises(RuntimeError) as context:
-            pixelCoordsFromPupilCoords(xpList, ypList, chipNames=['Det22']*10,
+            pixelCoordsFromPupilCoords(xpList, ypList, chipName=['Det22']*10,
                                  camera=self.camera)
         self.assertIn("You passed 10 chipNames", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
-            pixelCoordsFromRaDec(raList, decList, chipNames=['Det22']*10,
+            pixelCoordsFromRaDec(raList, decList, chipName=['Det22']*10,
                                  camera=self.camera,
                                  obs_metadata=obs,
                                  epoch=2000.0)
@@ -615,7 +615,7 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(np.radians(raList),
                                   np.radians(decList),
-                                  chipNames=['Det22']*10,
+                                  chipName=['Det22']*10,
                                   camera=self.camera,
                                   obs_metadata=obs,
                                   epoch=2000.0)
@@ -857,7 +857,7 @@ class PixelCoordTest(unittest.TestCase):
         inputChipNames = ['Det40'] * len(xPupList)
         xPixTest, yPixTest = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera,
                                                         includeDistortion=False,
-                                                        chipNames=inputChipNames)
+                                                        chipName=inputChipNames)
 
         np.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
         np.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
@@ -868,7 +868,7 @@ class PixelCoordTest(unittest.TestCase):
             xpx_f, ypx_f = pixelCoordsFromPupilCoords(xPupList[ix], yPupList[ix],
                                                       camera=self.camera,
                                                       includeDistortion=False,
-                                                      chipNames=inputChipNames[ix])
+                                                      chipName=inputChipNames[ix])
             self.assertIsInstance(xpx_f, np.float)
             self.assertIsInstance(ypx_f, np.float)
             self.assertAlmostEqual(xpx_f, xPixTest[ix], 12)
@@ -880,7 +880,7 @@ class PixelCoordTest(unittest.TestCase):
         xPix_one, yPix_one = pixelCoordsFromPupilCoords(xPupList, yPupList,
                                                         camera=self.camera,
                                                         includeDistortion=False,
-                                                        chipNames='Det40')
+                                                        chipName='Det40')
 
         np.testing.assert_array_almost_equal(xPix_one, xPixTest, 12)
         np.testing.assert_array_almost_equal(yPix_one, yPixTest, 12)
@@ -888,7 +888,7 @@ class PixelCoordTest(unittest.TestCase):
         xPix_one, yPix_one = pixelCoordsFromPupilCoords(xPupList, yPupList,
                                                         camera=self.camera,
                                                         includeDistortion=False,
-                                                        chipNames=['Det40'])
+                                                        chipName=['Det40'])
 
         np.testing.assert_array_almost_equal(xPix_one, xPixTest, 12)
         np.testing.assert_array_almost_equal(yPix_one, yPixTest, 12)
@@ -1523,27 +1523,27 @@ class ConversionFromPixelTest(unittest.TestCase):
             ra, dec = raDecFromPixelCoords(list(xPixList), yPixList,
                                            chipNameList, obs_metadata=obs,
                                            epoch=2000.0, camera=self.camera)
-        self.assertIn("The arg xPixList", context.exception.args[0])
+        self.assertIn("The arg xPix", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = raDecFromPixelCoords(xPixList, list(yPixList),
                                            chipNameList, obs_metadata=obs,
                                            epoch=2000.0, camera=self.camera)
         self.assertIn("The input arguments:", context.exception.args[0])
-        self.assertIn("yPixList", context.exception.args[0])
+        self.assertIn("yPix", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _raDecFromPixelCoords(list(xPixList), yPixList,
                                             chipNameList, obs_metadata=obs,
                                             epoch=2000.0, camera=self.camera)
-        self.assertIn("The arg xPixList", context.exception.args[0])
+        self.assertIn("The arg xPix", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _raDecFromPixelCoords(xPixList, list(yPixList),
                                             chipNameList, obs_metadata=obs,
                                             epoch=2000.0, camera=self.camera)
         self.assertIn("The input arguments:", context.exception.args[0])
-        self.assertIn("yPixList", context.exception.args[0])
+        self.assertIn("yPix", context.exception.args[0])
 
         # test that an error is raised if you pass in mismatched lists of
         # xPix and yPix
@@ -1678,7 +1678,7 @@ class ConversionFromPixelTest(unittest.TestCase):
             # with the results from pixelCoordsFromRaDec by taking the ra and dec
             # arrays found above and feeding them back into pixelCoordsFromRaDec
             # and seeing if we get the same results
-            xPixTest, yPixTest = pixelCoordsFromRaDec(raDeg, decDeg, chipNames=chipNameList,
+            xPixTest, yPixTest = pixelCoordsFromRaDec(raDeg, decDeg, chipName=chipNameList,
                                                       obs_metadata=obs,
                                                       epoch=2000.0,
                                                       camera=self.camera,

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -141,7 +141,6 @@ class ChipNameTest(unittest.TestCase):
         # the conversion from degrees to radians that happens inside that
         # method automatically casts lists as numpy arrays
 
-
         # verify that an exception is raised if the two coordinate arrays contain
         # different numbers of elements
         xpDummy = np.random.random_sample(nStars/2)
@@ -164,19 +163,6 @@ class ChipNameTest(unittest.TestCase):
         self.assertEqual(context.exception.message,
                          'You passed %d RAs and ' % (nStars/2) \
                          + '%d Decs to chipName.' % nStars)
-
-
-        # verify that an exception is raised if you call chipNameFromRaDec
-        # without an epoch
-        with self.assertRaises(RuntimeError) as context:
-            chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         'You need to pass an epoch into chipName')
-
-        with self.assertRaises(RuntimeError) as context:
-            _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         'You need to pass an epoch into chipName')
 
         # verify that an exception is raised if you call chipNameFromRaDec
         # without an ObservationMetaData
@@ -436,7 +422,6 @@ class PixelCoordTest(unittest.TestCase):
         # because the conversion from degrees to radians  that happens
         # inside that method automatically casts lists as numpy arrays
 
-
         # test that an exception is raised if you pass in mis-matched
         # input arrays
         with self.assertRaises(RuntimeError) as context:
@@ -492,23 +477,6 @@ class PixelCoordTest(unittest.TestCase):
         self.assertEqual(context.exception.message,
                          'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
 
-        # test that an exception is raised if you call one of the
-        # pixelCoordsFromRaDec methods without an epoch
-        with self.assertRaises(RuntimeError) as context:
-            pixelCoordsFromRaDec(raList, decList,
-                                 camera=self.camera,
-                                 obs_metadata=obs)
-        self.assertEqual(context.exception.message,
-                         'You need to pass an epoch into ' \
-                         + 'pixelCoordsFromRaDec')
-
-        with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(raList, decList,
-                                  camera=self.camera,
-                                  obs_metadata=obs)
-        self.assertEqual(context.exception.message,
-                         'You need to pass an epoch into ' \
-                         + 'pixelCoordsFromRaDec')
 
         # test that an exception is raised if you call one of the
         # pixelCoordsFromRaDec methods without an ObservationMetaData
@@ -1017,25 +985,6 @@ class FocalPlaneCoordTest(unittest.TestCase):
 
 
         # test that an error is raised if you call
-        # focalPlaneCoordsFromRaDec without an epoch
-        with self.assertRaises(RuntimeError) as context:
-            xf, yf = focalPlaneCoordsFromRaDec(raList, decList,
-                                               obs_metadata=obs,
-                                               camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You have to specify an epoch to run " \
-                         + "focalPlaneCoordsFromRaDec")
-
-        with self.assertRaises(RuntimeError) as context:
-            xf, yf = _focalPlaneCoordsFromRaDec(raList, decList,
-                                                obs_metadata=obs,
-                                                camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You have to specify an epoch to run " \
-                         + "focalPlaneCoordsFromRaDec")
-
-
-        # test that an error is raised if you call
         # focalPlaneCoordsFromRaDec without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromRaDec(raList, decList,
@@ -1272,18 +1221,6 @@ class ConversionFromPixelTest(unittest.TestCase):
         self.assertEqual(context.exception.message,
                          "You cannot call raDecFromPixelCoords without specifying a camera")
 
-        # test that an error is raised if you do not pass in an epoch
-        with self.assertRaises(RuntimeError) as context:
-            ra, dec = raDecFromPixelCoords(xPixList, yPixList, chipNameList,
-                                           obs_metadata=obs, camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You cannot call raDecFromPixelCoords without specifying an epoch")
-
-        with self.assertRaises(RuntimeError) as context:
-            ra, dec = _raDecFromPixelCoords(xPixList, yPixList, chipNameList,
-                                            obs_metadata=obs, camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You cannot call raDecFromPixelCoords without specifying an epoch")
 
         # test that an error is raised if you do not pass in an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1747,6 +1747,8 @@ class CornerTest(unittest.TestCase):
         self.assertEqual(corners[3][0], 3999)
         self.assertEqual(corners[3][1], 3999)
         self.assertEqual(len(corners), 4)
+        for row in corners:
+            self.assertEqual(len(row), 2)
 
     def testCornerRaDec_radians(self):
         """

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1094,6 +1094,25 @@ class FocalPlaneCoordTest(unittest.TestCase):
             self.assertFalse(np.isnan(y))
             self.assertFalse(y is None)
 
+        # now test that focalPlaneCoordsFromRaDec and
+        # focalPlaneCoordsFromPupilCoords give the same results
+        # when you pass the inputs in one-by-one
+        for ix in range(len(xf1)):
+            x_f, y_f = focalPlaneCoordsFromRaDec(raList[ix], decList[ix],
+                                                 camera=self.camera,
+                                                 obs_metadata=obs, epoch=2000.0)
+            self.assertIsInstance(x_f, float)
+            self.assertIsInstance(y_f, float)
+            self.assertEqual(x_f, xf1[ix])
+            self.assertEqual(y_f, yf1[ix])
+
+            x_f, y_f = focalPlaneCoordsFromPupilCoords(xPupList[ix], yPupList[ix],
+                                                       camera=self.camera)
+            self.assertIsInstance(x_f, float)
+            self.assertIsInstance(y_f, float)
+            self.assertEqual(x_f, xf1[ix])
+            self.assertEqual(y_f, yf1[ix])
+
 
     def testExceptions(self):
         """
@@ -1143,35 +1162,29 @@ class FocalPlaneCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromPupilCoords(list(xPupList), yPupList,
                                                      camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You must pass numpy arrays of xPupil and yPupil " \
-                         +"to focalPlaneCoordsFromPupilCoords")
+        self.assertIn("The arg xPupil", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromPupilCoords(xPupList, list(yPupList),
                                                      camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You must pass numpy arrays of xPupil and yPupil " \
-                         +"to focalPlaneCoordsFromPupilCoords")
-
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("yPupil", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(list(raList), decList,
                                                 obs_metadata=obs,
                                                 epoch=2000.0,
                                                 camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You must pass numpy arrays of RA and Dec to " \
-                         + "focalPlaneCoordsFromRaDec")
+        self.assertIn("The arg ra", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, list(decList),
                                                 obs_metadata=obs,
                                                 epoch=2000.0,
                                                 camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You must pass numpy arrays of RA and Dec to " \
-                         + "focalPlaneCoordsFromRaDec")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("dec", context.exception.args[0])
+
         # we do not have to run the test above on focalPlaneCoordsFromRaDec
         # because the conversion to radians automatically casts lists into
         # numpy arrays
@@ -1181,27 +1194,27 @@ class FocalPlaneCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromPupilCoords(xPupList, yPupList[0:4],
                                                      camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You specified 10 xPupil and 4 yPupil coordinates " \
-                         + "in focalPlaneCoordsFromPupilCoords")
+        self.assertEqual(context.exception.args[0],
+                         "The arrays input to focalPlaneCoordsFromPupilCoords "
+                         "all need to have the same length")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromRaDec(raList, decList[0:4],
                                                obs_metadata=obs,
                                                epoch=2000.0,
                                                camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You specified 10 RAs and 4 Decs in " \
-                         + "focalPlaneCoordsFromRaDec")
+        self.assertEqual(context.exception.args[0],
+                         "The arrays input to focalPlaneCoordsFromRaDec "
+                         "all need to have the same length")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, decList[0:4],
                                                 obs_metadata=obs,
                                                 epoch=2000.0,
                                                 camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         "You specified 10 RAs and 4 Decs in " \
-                         + "focalPlaneCoordsFromRaDec")
+        self.assertEqual(context.exception.args[0],
+                         "The arrays input to focalPlaneCoordsFromRaDec "
+                         "all need to have the same length")
 
 
         # test that an error is raised if you call

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 import os
-import numpy
+import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 from lsst.utils import getPackageDir
@@ -38,7 +38,7 @@ class ChipNameTest(unittest.TestCase):
         cls.camera = ReturnCamera(cameraDir)
 
     def setUp(self):
-        numpy.random.seed(45532)
+        np.random.seed(45532)
 
 
     def testRuns(self):
@@ -54,8 +54,8 @@ class ChipNameTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=mjd, rotSkyPos=rotSkyPos)
 
-        raList = (numpy.random.random_sample(nStars)-0.5)*1000.0/3600.0 + ra0
-        decList = (numpy.random.random_sample(nStars)-0.5)*1000.0/3600.0 + dec0
+        raList = (np.random.random_sample(nStars)-0.5)*1000.0/3600.0 + ra0
+        decList = (np.random.random_sample(nStars)-0.5)*1000.0/3600.0 + dec0
 
         xpList, ypList = pupilCoordsFromRaDec(raList, decList,
                                                    obs_metadata=obs,
@@ -66,15 +66,15 @@ class ChipNameTest(unittest.TestCase):
                                    epoch=2000.0,
                                    camera=self.camera)
 
-        names2 = _chipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
+        names2 = _chipNameFromRaDec(np.radians(raList), np.radians(decList),
                                     obs_metadata=obs,
                                     epoch=2000.0,
                                     camera=self.camera)
 
         names3 = chipNameFromPupilCoords(xpList, ypList, camera=self.camera)
 
-        numpy.testing.assert_array_equal(names1, names2)
-        numpy.testing.assert_array_equal(names1, names3)
+        np.testing.assert_array_equal(names1, names2)
+        np.testing.assert_array_equal(names1, names3)
 
         isNone = 0
         isNotNone = 0
@@ -93,8 +93,8 @@ class ChipNameTest(unittest.TestCase):
         """
 
         nStars = 10
-        xpList = numpy.random.random_sample(nStars)*0.1
-        ypList = numpy.random.random_sample(nStars)*0.1
+        xpList = np.random.random_sample(nStars)*0.1
+        ypList = np.random.random_sample(nStars)*0.1
 
         obs = ObservationMetaData(pointingRA=25.0, pointingDec=112.0, mjd=42351.0,
                                   rotSkyPos=35.0)
@@ -144,7 +144,7 @@ class ChipNameTest(unittest.TestCase):
 
         # verify that an exception is raised if the two coordinate arrays contain
         # different numbers of elements
-        xpDummy = numpy.random.random_sample(nStars/2)
+        xpDummy = np.random.random_sample(nStars/2)
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
         self.assertEqual(context.exception.message,
@@ -236,10 +236,10 @@ class ChipNameTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=mjd, rotSkyPos=rotSkyPos)
 
-        for badVal in [numpy.NaN, None]:
+        for badVal in [np.NaN, None]:
 
-            raList = (numpy.random.random_sample(nStars)-0.5)*5.0/3600.0 + ra0
-            decList = (numpy.random.random_sample(nStars)-0.5)*5.0/3600.0 + dec0
+            raList = (np.random.random_sample(nStars)-0.5)*5.0/3600.0 + ra0
+            decList = (np.random.random_sample(nStars)-0.5)*5.0/3600.0 + dec0
 
             raList[5] = badVal
             raList[10] = badVal
@@ -253,13 +253,13 @@ class ChipNameTest(unittest.TestCase):
             names1 = chipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
                                             camera=self.camera)
 
-            names2 = _chipNameFromRaDec(numpy.radians(raList), numpy.radians(decList),
+            names2 = _chipNameFromRaDec(np.radians(raList), np.radians(decList),
                                             obs_metadata=obs, epoch=2000.0, camera=self.camera)
 
             names3 = chipNameFromPupilCoords(xpList, ypList, camera=self.camera)
 
-            numpy.testing.assert_array_equal(names1, names2)
-            numpy.testing.assert_array_equal(names1, names3)
+            np.testing.assert_array_equal(names1, names2)
+            np.testing.assert_array_equal(names1, names3)
 
             for ix in range(len(names1)):
                 if ix != 5 and ix != 10 and ix != 25:
@@ -281,7 +281,7 @@ class PixelCoordTest(unittest.TestCase):
         cls.camera = ReturnCamera(cameraDir)
 
     def setUp(self):
-        numpy.random.seed(11324)
+        np.random.seed(11324)
 
 
     def testConsistency(self):
@@ -295,8 +295,8 @@ class PixelCoordTest(unittest.TestCase):
                                   mjd=52350.0, rotSkyPos=27.0)
 
         nStars = 100
-        raList = (numpy.random.random_sample(nStars)-0.5)*500.0/3600.0 + ra0
-        decList = (numpy.random.random_sample(nStars)-0.5)*500.0/3600.0 + dec0
+        raList = (np.random.random_sample(nStars)-0.5)*500.0/3600.0 + ra0
+        decList = (np.random.random_sample(nStars)-0.5)*500.0/3600.0 + dec0
 
         xpList, ypList = pupilCoordsFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0)
 
@@ -308,7 +308,7 @@ class PixelCoordTest(unittest.TestCase):
             xx1, yy1 = pixelCoordsFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
                                             camera=self.camera, includeDistortion=includeDistortion)
 
-            xx2, yy2 = _pixelCoordsFromRaDec(numpy.radians(raList), numpy.radians(decList),
+            xx2, yy2 = _pixelCoordsFromRaDec(np.radians(raList), np.radians(decList),
                                              obs_metadata=obs, epoch=2000.0,
                                              camera=self.camera, includeDistortion=includeDistortion)
 
@@ -323,23 +323,23 @@ class PixelCoordTest(unittest.TestCase):
                                             camera=self.camera, includeDistortion=includeDistortion,
                                             chipNames=chipNameList)
 
-            xx6, yy6 = _pixelCoordsFromRaDec(numpy.radians(raList), numpy.radians(decList),
+            xx6, yy6 = _pixelCoordsFromRaDec(np.radians(raList), np.radians(decList),
                                              obs_metadata=obs, epoch=2000.0,
                                              camera=self.camera, includeDistortion=includeDistortion,
                                              chipNames=chipNameList)
 
 
-            numpy.testing.assert_array_equal(xx1, xx2)
-            numpy.testing.assert_array_equal(xx1, xx3)
-            numpy.testing.assert_array_equal(xx1, xx4)
-            numpy.testing.assert_array_equal(xx1, xx5)
-            numpy.testing.assert_array_equal(xx1, xx6)
+            np.testing.assert_array_equal(xx1, xx2)
+            np.testing.assert_array_equal(xx1, xx3)
+            np.testing.assert_array_equal(xx1, xx4)
+            np.testing.assert_array_equal(xx1, xx5)
+            np.testing.assert_array_equal(xx1, xx6)
 
-            numpy.testing.assert_array_equal(yy1, yy2)
-            numpy.testing.assert_array_equal(yy1, yy3)
-            numpy.testing.assert_array_equal(yy1, yy4)
-            numpy.testing.assert_array_equal(yy1, yy5)
-            numpy.testing.assert_array_equal(yy1, yy6)
+            np.testing.assert_array_equal(yy1, yy2)
+            np.testing.assert_array_equal(yy1, yy3)
+            np.testing.assert_array_equal(yy1, yy4)
+            np.testing.assert_array_equal(yy1, yy5)
+            np.testing.assert_array_equal(yy1, yy6)
 
             # make sure that objects which do not fall on a chip
             # get NaN pixel coords
@@ -347,12 +347,12 @@ class PixelCoordTest(unittest.TestCase):
             ctNotNaN = 0
             for x, y, name in zip(xx1, yy1, chipNameList):
                 if name is None:
-                    self.assertTrue(numpy.isnan(x))
-                    self.assertTrue(numpy.isnan(y))
+                    self.assertTrue(np.isnan(x))
+                    self.assertTrue(np.isnan(y))
                     ctNaN += 1
                 else:
-                    self.assertFalse(numpy.isnan(x))
-                    self.assertFalse(numpy.isnan(y))
+                    self.assertFalse(np.isnan(x))
+                    self.assertFalse(np.isnan(y))
                     ctNotNaN += 1
 
             self.assertGreater(ctNaN, 0)
@@ -365,15 +365,15 @@ class PixelCoordTest(unittest.TestCase):
         they should
         """
         nPoints = 100
-        xpList = numpy.random.random_sample(nPoints)*numpy.radians(1.0)
-        ypList = numpy.random.random_sample(nPoints)*numpy.radians(1.0)
+        xpList = np.random.random_sample(nPoints)*np.radians(1.0)
+        ypList = np.random.random_sample(nPoints)*np.radians(1.0)
         obs = ObservationMetaData(pointingRA=25.0,
                                   pointingDec=-36.0,
                                   rotSkyPos=122.0,
                                   mjd=41325.0)
 
-        raList = numpy.random.random_sample(nPoints)*1.0+25.0
-        decList = numpy.random.random_sample(nPoints)*1.0-36.0
+        raList = np.random.random_sample(nPoints)*1.0+25.0
+        decList = np.random.random_sample(nPoints)*1.0-36.0
 
         # check that an error is raised when you forget to
         # pass in a camera
@@ -389,8 +389,8 @@ class PixelCoordTest(unittest.TestCase):
                          'Camera not specified.  Cannot calculate pixel coordinates.')
 
         with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(numpy.radians(raList),
-                                  numpy.radians(decList),
+            _pixelCoordsFromRaDec(np.radians(raList),
+                                  np.radians(decList),
                                   obs_metadata=obs,
                                   epoch=2000.0)
         self.assertEqual(context.exception.message,
@@ -414,8 +414,8 @@ class PixelCoordTest(unittest.TestCase):
                          + 'to pixelCoordsFromPupilCoords')
 
         with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(list(numpy.radians(raList)),
-                                  numpy.radians(decList),
+            _pixelCoordsFromRaDec(list(np.radians(raList)),
+                                  np.radians(decList),
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
@@ -424,8 +424,8 @@ class PixelCoordTest(unittest.TestCase):
                          + 'to pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(numpy.radians(raList),
-                                  list(numpy.radians(decList)),
+            _pixelCoordsFromRaDec(np.radians(raList),
+                                  list(np.radians(decList)),
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
@@ -456,8 +456,8 @@ class PixelCoordTest(unittest.TestCase):
                          'to pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(numpy.radians(raList),
-                                  numpy.radians(decList[0:10]),
+            _pixelCoordsFromRaDec(np.radians(raList),
+                                  np.radians(decList[0:10]),
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
@@ -483,8 +483,8 @@ class PixelCoordTest(unittest.TestCase):
                          'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
-            _pixelCoordsFromRaDec(numpy.radians(raList),
-                                  numpy.radians(decList),
+            _pixelCoordsFromRaDec(np.radians(raList),
+                                  np.radians(decList),
                                   chipNames=['Det22']*10,
                                   camera=self.camera,
                                   obs_metadata=obs,
@@ -607,13 +607,13 @@ class PixelCoordTest(unittest.TestCase):
         # assemble a bunch of displacements in pixels
         dxPixList = []
         dyPixList = []
-        for xx in numpy.arange(-1999.0, 1999.0, 500.0):
-            for yy in numpy.arange(-1999.0, 1999.0, 500.0):
+        for xx in np.arange(-1999.0, 1999.0, 500.0):
+            for yy in np.arange(-1999.0, 1999.0, 500.0):
                 dxPixList.append(xx)
                 dyPixList.append(yy)
 
-        dxPixList = numpy.array(dxPixList)
-        dyPixList = numpy.array(dyPixList)
+        dxPixList = np.array(dxPixList)
+        dyPixList = np.array(dyPixList)
 
         # convert to raidans
         dxPupList = radiansFromArcsec(dxPixList*arcsecPerPixel)
@@ -622,20 +622,20 @@ class PixelCoordTest(unittest.TestCase):
         # assemble a bunch of test pupil coordinate pairs
         xPupList = x22 + dxPupList
         yPupList = y22 + dyPupList
-        xPupList = numpy.append(xPupList, x32 + dxPupList)
-        yPupList = numpy.append(yPupList, y32 + dyPupList)
-        xPupList = numpy.append(xPupList, x40 + dxPupList)
-        yPupList = numpy.append(yPupList, y40 + dyPupList)
+        xPupList = np.append(xPupList, x32 + dxPupList)
+        yPupList = np.append(yPupList, y32 + dyPupList)
+        xPupList = np.append(xPupList, x40 + dxPupList)
+        yPupList = np.append(yPupList, y40 + dyPupList)
 
         # this is what the chipNames ought to be for these points
-        chipNameControl = numpy.array(['Det22'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det32'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det40'] * len(dxPupList))
+        chipNameControl = np.array(['Det22'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det32'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det40'] * len(dxPupList))
 
         chipNameTest = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
 
         # verify that the test points fall on the expected chips
-        numpy.testing.assert_array_equal(chipNameControl, chipNameTest)
+        np.testing.assert_array_equal(chipNameControl, chipNameTest)
 
         # Note, the somewhat backwards way in which we go from dxPixList to
         # xPixControl is due to the fact that pixel coordinates are actually
@@ -644,17 +644,17 @@ class PixelCoordTest(unittest.TestCase):
         # in pupil coordinates
         xPixControl = 1999.5 + dyPixList
         yPixControl = 1999.5 - dxPixList
-        xPixControl = numpy.append(xPixControl, 1999.5 + dyPixList)
-        yPixControl = numpy.append(yPixControl, 1999.5 - dxPixList)
-        xPixControl = numpy.append(xPixControl, 1999.5 + dyPixList)
-        yPixControl = numpy.append(yPixControl, 1999.5 - dxPixList)
+        xPixControl = np.append(xPixControl, 1999.5 + dyPixList)
+        yPixControl = np.append(yPixControl, 1999.5 - dxPixList)
+        xPixControl = np.append(xPixControl, 1999.5 + dyPixList)
+        yPixControl = np.append(yPixControl, 1999.5 - dxPixList)
 
         # verify that the pixel coordinates are as expected to within 0.01 pixel
         xPixTest, yPixTest = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera,
                                                         includeDistortion=False)
 
-        numpy.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
-        numpy.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
+        np.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
+        np.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
 
 
     def testOffChipResults(self):
@@ -692,13 +692,13 @@ class PixelCoordTest(unittest.TestCase):
         # assemble a bunch of displacements in pixels
         dxPixList = []
         dyPixList = []
-        for xx in numpy.arange(-1999.0, 1999.0, 500.0):
-            for yy in numpy.arange(-1999.0, 1999.0, 500.0):
+        for xx in np.arange(-1999.0, 1999.0, 500.0):
+            for yy in np.arange(-1999.0, 1999.0, 500.0):
                 dxPixList.append(xx)
                 dyPixList.append(yy)
 
-        dxPixList = numpy.array(dxPixList)
-        dyPixList = numpy.array(dyPixList)
+        dxPixList = np.array(dxPixList)
+        dyPixList = np.array(dyPixList)
 
         # convert to raidans
         dxPupList = radiansFromArcsec(dxPixList*arcsecPerPixel)
@@ -707,20 +707,20 @@ class PixelCoordTest(unittest.TestCase):
         # assemble a bunch of test pupil coordinate pairs
         xPupList = x22 + dxPupList
         yPupList = y22 + dyPupList
-        xPupList = numpy.append(xPupList, x32 + dxPupList)
-        yPupList = numpy.append(yPupList, y32 + dyPupList)
-        xPupList = numpy.append(xPupList, x40 + dxPupList)
-        yPupList = numpy.append(yPupList, y40 + dyPupList)
+        xPupList = np.append(xPupList, x32 + dxPupList)
+        yPupList = np.append(yPupList, y32 + dyPupList)
+        xPupList = np.append(xPupList, x40 + dxPupList)
+        yPupList = np.append(yPupList, y40 + dyPupList)
 
         # this is what the chipNames ought to be for these points
-        chipNameControl = numpy.array(['Det22'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det32'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det40'] * len(dxPupList))
+        chipNameControl = np.array(['Det22'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det32'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det40'] * len(dxPupList))
 
         chipNameTest = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
 
         # verify that the test points fall on the expected chips
-        numpy.testing.assert_array_equal(chipNameControl, chipNameTest)
+        np.testing.assert_array_equal(chipNameControl, chipNameTest)
 
         # Note, the somewhat backwards way in which we go from dxPupList to
         # xPixControl is due to the fact that pixel coordinates are actually
@@ -736,8 +736,8 @@ class PixelCoordTest(unittest.TestCase):
                                                         includeDistortion=False,
                                                         chipNames=inputChipNames)
 
-        numpy.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
-        numpy.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
+        np.testing.assert_array_almost_equal(xPixTest, xPixControl, 2)
+        np.testing.assert_array_almost_equal(yPixTest, yPixControl, 2)
 
 
 
@@ -752,8 +752,8 @@ class PixelCoordTest(unittest.TestCase):
                                   rotSkyPos=42.0, mjd=42356.0)
 
         nStars = 10
-        raList = numpy.random.random_sample(100)*100.0/3600.0 + ra0
-        decList = numpy.random.random_sample(100)*100.0/3600.0 + dec0
+        raList = np.random.random_sample(100)*100.0/3600.0 + ra0
+        decList = np.random.random_sample(100)*100.0/3600.0 + dec0
         chipNameList = chipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
                                          camera=self.camera)
 
@@ -768,12 +768,12 @@ class PixelCoordTest(unittest.TestCase):
                                                   epoch=2000.0, camera=self.camera)
 
         for xx, yy in zip(xPixList, yPixList):
-            self.assertFalse(numpy.isnan(xx))
-            self.assertFalse(numpy.isnan(yy))
+            self.assertFalse(np.isnan(xx))
+            self.assertFalse(np.isnan(yy))
             self.assertFalse(xx is None)
             self.assertFalse(yy is None)
 
-        for badVal in [numpy.NaN, None]:
+        for badVal in [np.NaN, None]:
             raList[5] = badVal
             decList[7] = badVal
             raList[9] = badVal
@@ -784,24 +784,24 @@ class PixelCoordTest(unittest.TestCase):
 
             for ix, (xx, yy) in enumerate(zip(xPixList, yPixList)):
                 if ix in [5, 7, 9]:
-                    self.assertTrue(numpy.isnan(xx))
-                    self.assertTrue(numpy.isnan(yy))
+                    self.assertTrue(np.isnan(xx))
+                    self.assertTrue(np.isnan(yy))
                 else:
-                    self.assertFalse(numpy.isnan(xx))
-                    self.assertFalse(numpy.isnan(yy))
+                    self.assertFalse(np.isnan(xx))
+                    self.assertFalse(np.isnan(yy))
                     self.assertIsNotNone(xx, None)
                     self.assertIsNotNone(yy, None)
 
-            xPixList, yPixList = _pixelCoordsFromRaDec(numpy.radians(raList), numpy.radians(decList),
+            xPixList, yPixList = _pixelCoordsFromRaDec(np.radians(raList), np.radians(decList),
                                                        obs_metadata=obs, epoch=2000.0, camera=self.camera)
 
             for ix, (xx, yy) in enumerate(zip(xPixList, yPixList)):
                 if ix in [5, 7, 9]:
-                    self.assertTrue(numpy.isnan(xx))
-                    self.assertTrue(numpy.isnan(yy))
+                    self.assertTrue(np.isnan(xx))
+                    self.assertTrue(np.isnan(yy))
                 else:
-                    self.assertFalse(numpy.isnan(xx))
-                    self.assertFalse(numpy.isnan(yy))
+                    self.assertFalse(np.isnan(xx))
+                    self.assertFalse(np.isnan(yy))
                     self.assertIsNotNone(xx, None)
                     self.assertIsNotNone(yy, None)
 
@@ -812,11 +812,11 @@ class PixelCoordTest(unittest.TestCase):
             xPixList, yPixList = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera)
             for ix, (xx, yy) in enumerate(zip(xPixList, yPixList)):
                 if ix in [5, 7, 9]:
-                    self.assertTrue(numpy.isnan(xx))
-                    self.assertTrue(numpy.isnan(yy))
+                    self.assertTrue(np.isnan(xx))
+                    self.assertTrue(np.isnan(yy))
                 else:
-                    self.assertFalse(numpy.isnan(xx))
-                    self.assertFalse(numpy.isnan(yy))
+                    self.assertFalse(np.isnan(xx))
+                    self.assertFalse(np.isnan(yy))
                     self.assertIsNotNone(xx, None)
                     self.assertIsNotNone(yy, None)
 
@@ -831,8 +831,8 @@ class PixelCoordTest(unittest.TestCase):
         If we take that away, the test will no longer pass.
         """
         nStars = 100
-        xp = radiansFromArcsec((numpy.random.random_sample(100)-0.5)*100.0)
-        yp = radiansFromArcsec((numpy.random.random_sample(100)-0.5)*100.0)
+        xp = radiansFromArcsec((np.random.random_sample(100)-0.5)*100.0)
+        yp = radiansFromArcsec((np.random.random_sample(100)-0.5)*100.0)
 
         xu, yu = pixelCoordsFromPupilCoords(xp, yp, camera=self.camera, includeDistortion=False)
         xd, yd = pixelCoordsFromPupilCoords(xp, yp, camera=self.camera, includeDistortion=True)
@@ -840,10 +840,10 @@ class PixelCoordTest(unittest.TestCase):
         # just verify that the distorted versus undistorted coordinates vary in the
         # 4th decimal place
         with self.assertRaises(AssertionError) as context:
-            numpy.testing.assert_array_almost_equal(xu, xd, 4)
+            np.testing.assert_array_almost_equal(xu, xd, 4)
 
         with self.assertRaises(AssertionError) as context:
-            numpy.testing.assert_array_almost_equal(yu, yd, 4)
+            np.testing.assert_array_almost_equal(yu, yd, 4)
 
 
 
@@ -856,7 +856,7 @@ class FocalPlaneCoordTest(unittest.TestCase):
         cls.camera = ReturnCamera(cameraDir)
 
     def setUp(self):
-        numpy.random.seed(8374522)
+        np.random.seed(8374522)
 
 
     def testConsistency(self):
@@ -870,14 +870,14 @@ class FocalPlaneCoordTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=43257.0, rotSkyPos = 127.0)
 
-        raCenter, decCenter = observedFromICRS(numpy.array([ra0]),
-                                               numpy.array([dec0]),
+        raCenter, decCenter = observedFromICRS(np.array([ra0]),
+                                               np.array([dec0]),
                                                obs_metadata=obs,
                                                epoch=2000.0)
 
         nStars = 100
-        raList = numpy.random.random_sample(nStars)*1000.0/3600.0 + raCenter[0]
-        decList = numpy.random.random_sample(nStars)*1000.0/3600.0 + decCenter[0]
+        raList = np.random.random_sample(nStars)*1000.0/3600.0 + raCenter[0]
+        decList = np.random.random_sample(nStars)*1000.0/3600.0 + decCenter[0]
 
         xPupList, yPupList = pupilCoordsFromRaDec(raList, decList,
                                                   obs_metadata=obs,
@@ -887,23 +887,23 @@ class FocalPlaneCoordTest(unittest.TestCase):
                                              obs_metadata=obs,
                                              epoch=2000.0, camera=self.camera)
 
-        xf2, yf2 = _focalPlaneCoordsFromRaDec(numpy.radians(raList),
-                                              numpy.radians(decList),
+        xf2, yf2 = _focalPlaneCoordsFromRaDec(np.radians(raList),
+                                              np.radians(decList),
                                               obs_metadata=obs,
                                               epoch=2000.0, camera=self.camera)
 
         xf3, yf3 = focalPlaneCoordsFromPupilCoords(xPupList, yPupList,
                                                    camera=self.camera)
 
-        numpy.testing.assert_array_equal(xf1, xf2)
-        numpy.testing.assert_array_equal(xf1, xf3)
-        numpy.testing.assert_array_equal(yf1, yf2)
-        numpy.testing.assert_array_equal(yf1, yf3)
+        np.testing.assert_array_equal(xf1, xf2)
+        np.testing.assert_array_equal(xf1, xf3)
+        np.testing.assert_array_equal(yf1, yf2)
+        np.testing.assert_array_equal(yf1, yf3)
 
         for x, y in zip(xf1, yf1):
-            self.assertFalse(numpy.isnan(x))
+            self.assertFalse(np.isnan(x))
             self.assertFalse(x is None)
-            self.assertFalse(numpy.isnan(y))
+            self.assertFalse(np.isnan(y))
             self.assertFalse(y is None)
 
 
@@ -919,8 +919,8 @@ class FocalPlaneCoordTest(unittest.TestCase):
                                   rotSkyPos=61.0, mjd=52349.0)
 
         nStars = 10
-        raList = (numpy.random.random_sample(nStars)-0.5) + ra0
-        decList = (numpy.random.random_sample(nStars)-0.5) + dec0
+        raList = (np.random.random_sample(nStars)-0.5) + ra0
+        decList = (np.random.random_sample(nStars)-0.5) + dec0
         xPupList, yPupList = pupilCoordsFromRaDec(raList, decList,
                                                   obs_metadata=obs,
                                                   epoch=2000.0)
@@ -1133,13 +1133,13 @@ class FocalPlaneCoordTest(unittest.TestCase):
         # assemble a bunch of displacements in pixels
         dxPixList = []
         dyPixList = []
-        for xx in numpy.arange(-1999.0, 1999.0, 500.0):
-            for yy in numpy.arange(-1999.0, 1999.0, 500.0):
+        for xx in np.arange(-1999.0, 1999.0, 500.0):
+            for yy in np.arange(-1999.0, 1999.0, 500.0):
                 dxPixList.append(xx)
                 dyPixList.append(yy)
 
-        dxPixList = numpy.array(dxPixList)
-        dyPixList = numpy.array(dyPixList)
+        dxPixList = np.array(dxPixList)
+        dyPixList = np.array(dyPixList)
 
         # convert to raidans
         dxPupList = radiansFromArcsec(dxPixList*arcsecPerPixel)
@@ -1148,20 +1148,20 @@ class FocalPlaneCoordTest(unittest.TestCase):
         # assemble a bunch of test pupil coordinate pairs
         xPupList = x22 + dxPupList
         yPupList = y22 + dyPupList
-        xPupList = numpy.append(xPupList, x32 + dxPupList)
-        yPupList = numpy.append(yPupList, y32 + dyPupList)
-        xPupList = numpy.append(xPupList, x40 + dxPupList)
-        yPupList = numpy.append(yPupList, y40 + dyPupList)
+        xPupList = np.append(xPupList, x32 + dxPupList)
+        yPupList = np.append(yPupList, y32 + dyPupList)
+        xPupList = np.append(xPupList, x40 + dxPupList)
+        yPupList = np.append(yPupList, y40 + dyPupList)
 
         # this is what the chipNames ought to be for these points
-        chipNameControl = numpy.array(['Det22'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det32'] * len(dxPupList))
-        chipNameControl = numpy.append(chipNameControl, ['Det40'] * len(dxPupList))
+        chipNameControl = np.array(['Det22'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det32'] * len(dxPupList))
+        chipNameControl = np.append(chipNameControl, ['Det40'] * len(dxPupList))
 
         chipNameTest = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
 
         # verify that the test points fall on the expected chips
-        numpy.testing.assert_array_equal(chipNameControl, chipNameTest)
+        np.testing.assert_array_equal(chipNameControl, chipNameTest)
 
         # convert into millimeters on the focal plane
         xFocalControl = arcsecFromRadians(xPupList)*mmPerArcsec
@@ -1169,8 +1169,8 @@ class FocalPlaneCoordTest(unittest.TestCase):
 
         xFocalTest, yFocalTest = focalPlaneCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera)
 
-        numpy.testing.assert_array_almost_equal(xFocalTest, xFocalControl, 3)
-        numpy.testing.assert_array_almost_equal(yFocalTest, yFocalControl, 3)
+        np.testing.assert_array_almost_equal(xFocalTest, xFocalControl, 3)
+        np.testing.assert_array_almost_equal(yFocalTest, yFocalControl, 3)
 
 
 class ConversionFromPixelTest(unittest.TestCase):
@@ -1182,7 +1182,7 @@ class ConversionFromPixelTest(unittest.TestCase):
         cls.camera = ReturnCamera(cameraDir)
 
     def setUp(self):
-        numpy.random.seed(543)
+        np.random.seed(543)
 
     def testPupCoordsException(self):
         """
@@ -1190,8 +1190,8 @@ class ConversionFromPixelTest(unittest.TestCase):
         call it without a camera
         """
         nStars = 100
-        xPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
-        yPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
+        xPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
+        yPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
         chipNameList = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
         xPix, yPix = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera)
         with self.assertRaises(RuntimeError) as context:
@@ -1208,8 +1208,8 @@ class ConversionFromPixelTest(unittest.TestCase):
         """
 
         nStars = 100
-        xPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
-        yPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
+        xPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
+        yPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
         chipNameList = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
         for includeDistortion in [True, False]:
             xPix, yPix = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera,
@@ -1218,13 +1218,13 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                             includeDistortion=includeDistortion)
 
             dx = arcsecFromRadians(xPupTest-xPupList)
-            numpy.testing.assert_array_almost_equal(dx, numpy.zeros(len(dx)), 9)
+            np.testing.assert_array_almost_equal(dx, np.zeros(len(dx)), 9)
             dy = arcsecFromRadians(yPupTest-yPupList)
-            numpy.testing.assert_array_almost_equal(dy, numpy.zeros(len(dy)), 9)
+            np.testing.assert_array_almost_equal(dy, np.zeros(len(dy)), 9)
 
             ctNaN = 0
             for x, y in zip(xPupTest, yPupTest):
-                if numpy.isnan(x) or numpy.isnan(y):
+                if np.isnan(x) or np.isnan(y):
                     ctNaN += 1
             self.assertLess(ctNaN, len(xPupTest)/10)
 
@@ -1233,14 +1233,14 @@ class ConversionFromPixelTest(unittest.TestCase):
         Test that points which do not have a chip return NaN for pupilCoordsFromPixelCoords
         """
         nStars = 10
-        xPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
-        yPupList = radiansFromArcsec((numpy.random.random_sample(nStars)-0.5)*320.0)
+        xPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
+        yPupList = radiansFromArcsec((np.random.random_sample(nStars)-0.5)*320.0)
         chipNameList = chipNameFromPupilCoords(xPupList, yPupList, camera=self.camera)
         chipNameList[5] = None
         xPix, yPix = pixelCoordsFromPupilCoords(xPupList, yPupList, camera=self.camera)
         xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPix, yPix, chipNameList, camera=self.camera)
-        self.assertTrue(numpy.isnan(xPupTest[5]))
-        self.assertTrue(numpy.isnan(yPupTest[5]))
+        self.assertTrue(np.isnan(xPupTest[5]))
+        self.assertTrue(np.isnan(yPupTest[5]))
 
 
     def testRaDecExceptions(self):
@@ -1253,10 +1253,10 @@ class ConversionFromPixelTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=43525.0, rotSkyPos=145.0)
 
-        xPixList = numpy.random.random_sample(nStars)*4000.0
-        yPixList = numpy.random.random_sample(nStars)*4000.0
+        xPixList = np.random.random_sample(nStars)*4000.0
+        yPixList = np.random.random_sample(nStars)*4000.0
 
-        chipDexList = numpy.random.random_integers(0, len(self.camera)-1, nStars)
+        chipDexList = np.random.random_integers(0, len(self.camera)-1, nStars)
         chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]].getName() for ii in chipDexList]
 
         # test that an error is raised if you do not pass in a camera
@@ -1414,10 +1414,10 @@ class ConversionFromPixelTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=43525.0, rotSkyPos=145.0)
 
-        xPixList = numpy.random.random_sample(nStars)*4000.0
-        yPixList = numpy.random.random_sample(nStars)*4000.0
+        xPixList = np.random.random_sample(nStars)*4000.0
+        yPixList = np.random.random_sample(nStars)*4000.0
 
-        chipDexList = numpy.random.random_integers(0, len(self.camera)-1, nStars)
+        chipDexList = np.random.random_integers(0, len(self.camera)-1, nStars)
         chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]].getName() for ii in chipDexList]
 
         for includeDistortion in [True, False]:
@@ -1433,10 +1433,10 @@ class ConversionFromPixelTest(unittest.TestCase):
 
 
             # first, make sure that the radians and degrees methods agree with each other
-            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
-            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(len(raRad)), 9)
-            dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
-            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(len(decRad)), 9)
+            dRa = arcsecFromRadians(raRad-np.radians(raDeg))
+            np.testing.assert_array_almost_equal(dRa, np.zeros(len(raRad)), 9)
+            dDec = arcsecFromRadians(decRad-np.radians(decDeg))
+            np.testing.assert_array_almost_equal(dDec, np.zeros(len(decRad)), 9)
 
             # now make sure that the results from raDecFromPixelCoords are consistent
             # with the results from pixelCoordsFromRaDec by taking the ra and dec
@@ -1447,7 +1447,7 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                       includeDistortion=includeDistortion)
 
 
-            distance = numpy.sqrt(numpy.power(xPixTest-xPixList,2)+numpy.power(yPixTest-yPixList,2))
+            distance = np.sqrt(np.power(xPixTest-xPixList,2)+np.power(yPixTest-yPixList,2))
             self.assertLess(distance.max(),0.2) # because of the imprecision in _icrsFromObserved, this is the best
                                                 # we can get; note that, in our test camera, each pixel is 10 microns
                                                 # in size and the plate scale is 2 arcsec per mm, so 0.2 pixels is
@@ -1469,10 +1469,10 @@ class ConversionFromPixelTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=43525.0, rotSkyPos=145.0)
 
-        xPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
-        yPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
+        xPixList = np.random.random_sample(nStars)*4000.0 + 4000.0
+        yPixList = np.random.random_sample(nStars)*4000.0 + 4000.0
 
-        chipDexList = numpy.random.random_integers(0, len(self.camera)-1, nStars)
+        chipDexList = np.random.random_integers(0, len(self.camera)-1, nStars)
         chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]].getName() for ii in chipDexList]
 
         for includeDistortion in [True, False]:
@@ -1488,10 +1488,10 @@ class ConversionFromPixelTest(unittest.TestCase):
 
 
             # first, make sure that the radians and degrees methods agree with each other
-            dRa = arcsecFromRadians(raRad-numpy.radians(raDeg))
-            numpy.testing.assert_array_almost_equal(dRa, numpy.zeros(len(raRad)), 9)
-            dDec = arcsecFromRadians(decRad-numpy.radians(decDeg))
-            numpy.testing.assert_array_almost_equal(dDec, numpy.zeros(len(decRad)), 9)
+            dRa = arcsecFromRadians(raRad-np.radians(raDeg))
+            np.testing.assert_array_almost_equal(dRa, np.zeros(len(raRad)), 9)
+            dDec = arcsecFromRadians(decRad-np.radians(decDeg))
+            np.testing.assert_array_almost_equal(dDec, np.zeros(len(decRad)), 9)
 
             # now make sure that the results from raDecFromPixelCoords are consistent
             # with the results from pixelCoordsFromRaDec by taking the ra and dec
@@ -1504,7 +1504,7 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                       includeDistortion=includeDistortion)
 
 
-            distance = numpy.sqrt(numpy.power(xPixTest-xPixList,2)+numpy.power(yPixTest-yPixList,2))
+            distance = np.sqrt(np.power(xPixTest-xPixList,2)+np.power(yPixTest-yPixList,2))
             self.assertLess(distance.max(),0.2) # because of the imprecision in _icrsFromObserved, this is the best
                                                 # we can get; note that, in our test camera, each pixel is 10 microns
                                                 # in size and the plate scale is 2 arcsec per mm, so 0.2 pixels is
@@ -1521,10 +1521,10 @@ class ConversionFromPixelTest(unittest.TestCase):
         If we take that away, the test will no longer pass.
         """
         nStars = 200
-        xPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
-        yPixList = numpy.random.random_sample(nStars)*4000.0 + 4000.0
+        xPixList = np.random.random_sample(nStars)*4000.0 + 4000.0
+        yPixList = np.random.random_sample(nStars)*4000.0 + 4000.0
 
-        chipDexList = numpy.random.random_integers(0, len(self.camera)-1, nStars)
+        chipDexList = np.random.random_integers(0, len(self.camera)-1, nStars)
         chipNameList = [self.camera[self.camera._nameDetectorDict.keys()[ii]].getName() for ii in chipDexList]
 
         xu, yu = pupilCoordsFromPixelCoords(xPixList, yPixList, chipNameList, camera=self.camera,
@@ -1535,10 +1535,10 @@ class ConversionFromPixelTest(unittest.TestCase):
 
         # just verify that the distorted versus undistorted coordinates vary in the 4th decimal
         with self.assertRaises(AssertionError) as context:
-            numpy.testing.assert_array_almost_equal(arcsecFromRadians(xu), arcsecFromRadians(xd), 4)
+            np.testing.assert_array_almost_equal(arcsecFromRadians(xu), arcsecFromRadians(xd), 4)
 
         with self.assertRaises(AssertionError) as context:
-            numpy.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
+            np.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
 
 
 class CornerTest(unittest.TestCase):
@@ -1581,8 +1581,8 @@ class CornerTest(unittest.TestCase):
         det_name = self.camera[4].getName()
         cornerTest = _getCornerRaDec(det_name, self.camera, obs)
 
-        ra_control, dec_control = _raDecFromPixelCoords(numpy.array([0, 0, 3999, 3999]),
-                                                        numpy.array([0, 3999, 0, 3999]),
+        ra_control, dec_control = _raDecFromPixelCoords(np.array([0, 0, 3999, 3999]),
+                                                        np.array([0, 3999, 0, 3999]),
                                                         [det_name]*4,
                                                         camera=self.camera,
                                                         obs_metadata=obs,
@@ -1611,7 +1611,7 @@ class CornerTest(unittest.TestCase):
         cornerRad = _getCornerRaDec(det_name, self.camera, obs)
         cornerDeg = getCornerRaDec(det_name, self.camera, obs)
         for cc1, cc2 in zip(cornerRad, cornerDeg):
-            dd = haversine(cc1[0], cc1[1], numpy.radians(cc2[0]), numpy.radians(cc2[1]))
+            dd = haversine(cc1[0], cc1[1], np.radians(cc2[0]), np.radians(cc2[1]))
             self.assertLess(arcsecFromRadians(dd), 0.000001)
 
 

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -772,7 +772,26 @@ class PixelCoordTest(unittest.TestCase):
             self.assertAlmostEqual(ypx_f, yPixTest[ix], 12)
 
         # We will now use this opportunity to test that pupilCoordsFromPixelCoords
-        # works when we pass in a list of pixel coords, but only one chip name
+        # and pixelCoordsFromPupilCoords work when we pass in a list of pixel
+        # coords, but only one chip name
+        xPix_one, yPix_one = pixelCoordsFromPupilCoords(xPupList, yPupList,
+                                                        camera=self.camera,
+                                                        includeDistortion=False,
+                                                        chipNames='Det40')
+
+        np.testing.assert_array_almost_equal(xPix_one, xPixTest, 12)
+        np.testing.assert_array_almost_equal(yPix_one, yPixTest, 12)
+
+        xPix_one, yPix_one = pixelCoordsFromPupilCoords(xPupList, yPupList,
+                                                        camera=self.camera,
+                                                        includeDistortion=False,
+                                                        chipNames=['Det40'])
+
+        np.testing.assert_array_almost_equal(xPix_one, xPixTest, 12)
+        np.testing.assert_array_almost_equal(yPix_one, yPixTest, 12)
+
+
+
         xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPixTest, yPixTest, 'Det40',
                                                         camera=self.camera,
                                                         includeDistortion=False)

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -771,6 +771,22 @@ class PixelCoordTest(unittest.TestCase):
             self.assertAlmostEqual(xpx_f, xPixTest[ix], 12)
             self.assertAlmostEqual(ypx_f, yPixTest[ix], 12)
 
+        # We will now use this opportunity to test that pupilCoordsFromPixelCoords
+        # works when we pass in a list of pixel coords, but only one chip name
+        xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPixTest, yPixTest, 'Det40',
+                                                        camera=self.camera,
+                                                        includeDistortion=False)
+
+        np.testing.assert_array_almost_equal(xPupTest, xPupList, 12)
+        np.testing.assert_array_almost_equal(yPupTest, yPupList, 12)
+
+        xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPixTest, yPixTest, ['Det40'],
+                                                        camera=self.camera,
+                                                        includeDistortion=False)
+
+        np.testing.assert_array_almost_equal(xPupTest, xPupList, 12)
+        np.testing.assert_array_almost_equal(yPupTest, yPupList, 12)
+
 
     def testNaN(self):
         """
@@ -1258,6 +1274,18 @@ class ConversionFromPixelTest(unittest.TestCase):
                 if np.isnan(x) or np.isnan(y):
                     ctNaN += 1
             self.assertLess(ctNaN, len(xPupTest)/10)
+
+            # test passing in pixel coordinates one at a time
+            for ix in range(len(xPupList)):
+                xp_f, yp_f = pupilCoordsFromPixelCoords(xPix[ix], yPix[ix], chipNameList[ix],
+                                                        camera=self.camera,
+                                                        includeDistortion=includeDistortion)
+
+                self.assertIsInstance(xp_f, np.float)
+                self.assertIsInstance(yp_f, np.float)
+                self.assertAlmostEqual(xp_f, xPupTest[ix], 12)
+                self.assertAlmostEqual(yp_f, yPupTest[ix], 12)
+
 
     def testPupCoordsNaN(self):
         """

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -283,70 +283,6 @@ class PixelCoordTest(unittest.TestCase):
     def setUp(self):
         numpy.random.seed(11324)
 
-    def testCornerPixels(self):
-        """
-        Test the method to get the pixel coordinates of the corner
-        of a detector
-        """
-        det_name = self.camera[0].getName()
-        corners = getCornerPixels(det_name, self.camera)
-        self.assertEqual(corners[0][0], 0)
-        self.assertEqual(corners[0][1], 0)
-        self.assertEqual(corners[1][0], 0)
-        self.assertEqual(corners[1][1], 3999)
-        self.assertEqual(corners[2][0], 3999)
-        self.assertEqual(corners[2][1], 0)
-        self.assertEqual(corners[3][0], 3999)
-        self.assertEqual(corners[3][1], 3999)
-        self.assertEqual(len(corners), 4)
-
-
-    def testCornerRaDec_radians(self):
-        """
-        Test that the method to return the Ra, Dec values of the corner
-        of a chip (in radians) works by validating its results against
-        known pixel corner values and the _raDecFromPixelCoords method,
-        which is tested separately.
-        """
-        obs = ObservationMetaData(pointingRA=23.0, pointingDec=-65.0,
-                                  rotSkyPos=52.1, mjd=59582.3)
-
-        det_name = self.camera[4].getName()
-        cornerTest = _getCornerRaDec(det_name, self.camera, obs)
-
-        ra_control, dec_control = _raDecFromPixelCoords(numpy.array([0, 0, 3999, 3999]),
-                                                        numpy.array([0, 3999, 0, 3999]),
-                                                        [det_name]*4,
-                                                        camera=self.camera,
-                                                        obs_metadata=obs,
-                                                        epoch=2000.0, includeDistortion=True)
-
-        # Loop over the control values and the corner values, using
-        # haversine() method to find the angular distance between the
-        # test and control values.  Assert that they are within
-        # 0.01 milli-arcsecond of each other
-        for rr1, dd1, cc in zip(ra_control, dec_control, cornerTest):
-            dd = haversine(rr1, dd1, cc[0], cc[1])
-            self.assertLess(arcsecFromRadians(dd), 0.00001)
-
-
-    def testCornerRaDec_degrees(self):
-        """
-        Test that method to get corner RA, Dec in degrees is consistent
-        with method to get corner RA, Dec in radians
-        """
-
-        obs = ObservationMetaData(pointingRA=31.0, pointingDec=-45.0,
-                                  rotSkyPos=46.2, mjd=59583.4)
-
-        det_name = self.camera[1].getName()
-
-        cornerRad = _getCornerRaDec(det_name, self.camera, obs)
-        cornerDeg = getCornerRaDec(det_name, self.camera, obs)
-        for cc1, cc2 in zip(cornerRad, cornerDeg):
-            dd = haversine(cc1[0], cc1[1], numpy.radians(cc2[0]), numpy.radians(cc2[1]))
-            self.assertLess(arcsecFromRadians(dd), 0.000001)
-
 
     def testConsistency(self):
         """
@@ -1605,6 +1541,78 @@ class ConversionFromPixelTest(unittest.TestCase):
             numpy.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
 
 
+class CornerTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cameraDir = getPackageDir('sims_coordUtils')
+        cameraDir = os.path.join(cameraDir, 'tests', 'cameraData')
+        cls.camera = ReturnCamera(cameraDir)
+
+
+    def testCornerPixels(self):
+        """
+        Test the method to get the pixel coordinates of the corner
+        of a detector
+        """
+        det_name = self.camera[0].getName()
+        corners = getCornerPixels(det_name, self.camera)
+        self.assertEqual(corners[0][0], 0)
+        self.assertEqual(corners[0][1], 0)
+        self.assertEqual(corners[1][0], 0)
+        self.assertEqual(corners[1][1], 3999)
+        self.assertEqual(corners[2][0], 3999)
+        self.assertEqual(corners[2][1], 0)
+        self.assertEqual(corners[3][0], 3999)
+        self.assertEqual(corners[3][1], 3999)
+        self.assertEqual(len(corners), 4)
+
+
+    def testCornerRaDec_radians(self):
+        """
+        Test that the method to return the Ra, Dec values of the corner
+        of a chip (in radians) works by validating its results against
+        known pixel corner values and the _raDecFromPixelCoords method,
+        which is tested separately.
+        """
+        obs = ObservationMetaData(pointingRA=23.0, pointingDec=-65.0,
+                                  rotSkyPos=52.1, mjd=59582.3)
+
+        det_name = self.camera[4].getName()
+        cornerTest = _getCornerRaDec(det_name, self.camera, obs)
+
+        ra_control, dec_control = _raDecFromPixelCoords(numpy.array([0, 0, 3999, 3999]),
+                                                        numpy.array([0, 3999, 0, 3999]),
+                                                        [det_name]*4,
+                                                        camera=self.camera,
+                                                        obs_metadata=obs,
+                                                        epoch=2000.0, includeDistortion=True)
+
+        # Loop over the control values and the corner values, using
+        # haversine() method to find the angular distance between the
+        # test and control values.  Assert that they are within
+        # 0.01 milli-arcsecond of each other
+        for rr1, dd1, cc in zip(ra_control, dec_control, cornerTest):
+            dd = haversine(rr1, dd1, cc[0], cc[1])
+            self.assertLess(arcsecFromRadians(dd), 0.00001)
+
+
+    def testCornerRaDec_degrees(self):
+        """
+        Test that method to get corner RA, Dec in degrees is consistent
+        with method to get corner RA, Dec in radians
+        """
+
+        obs = ObservationMetaData(pointingRA=31.0, pointingDec=-45.0,
+                                  rotSkyPos=46.2, mjd=59583.4)
+
+        det_name = self.camera[1].getName()
+
+        cornerRad = _getCornerRaDec(det_name, self.camera, obs)
+        cornerDeg = getCornerRaDec(det_name, self.camera, obs)
+        for cc1, cc2 in zip(cornerRad, cornerDeg):
+            dd = haversine(cc1[0], cc1[1], numpy.radians(cc2[0]), numpy.radians(cc2[1]))
+            self.assertLess(arcsecFromRadians(dd), 0.000001)
 
 
 def suite():
@@ -1614,6 +1622,7 @@ def suite():
     suites += unittest.makeSuite(PixelCoordTest)
     suites += unittest.makeSuite(FocalPlaneCoordTest)
     suites += unittest.makeSuite(ConversionFromPixelTest)
+    suites += unittest.makeSuite(CornerTest)
     return unittest.TestSuite(suites)
 
 def run(shouldExit=False):

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -5,8 +5,6 @@ import unittest
 import lsst.utils.tests as utilsTests
 from lsst.utils import getPackageDir
 
-from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
-
 from lsst.sims.utils import ObservationMetaData, radiansFromArcsec, arcsecFromRadians
 from lsst.sims.utils import haversine
 from lsst.sims.coordUtils.utils import ReturnCamera
@@ -29,6 +27,7 @@ from lsst.sims.coordUtils import raDecFromPixelCoords, _raDecFromPixelCoords
 
 from lsst.sims.coordUtils import getCornerPixels, _getCornerRaDec, getCornerRaDec
 
+
 class ChipNameTest(unittest.TestCase):
 
     @classmethod
@@ -40,7 +39,6 @@ class ChipNameTest(unittest.TestCase):
     def setUp(self):
         np.random.seed(45532)
 
-
     def testRuns(self):
         """
         Test that chipName runs, and that the various iterations of that method
@@ -49,7 +47,7 @@ class ChipNameTest(unittest.TestCase):
         nStars = 100
         ra0 = 45.0
         dec0 = -112.0
-        rotSkyPos=135.0
+        rotSkyPos = 135.0
         mjd = 42350.0
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=mjd, rotSkyPos=rotSkyPos)
@@ -58,8 +56,8 @@ class ChipNameTest(unittest.TestCase):
         decList = (np.random.random_sample(nStars)-0.5)*1000.0/3600.0 + dec0
 
         xpList, ypList = pupilCoordsFromRaDec(raList, decList,
-                                                   obs_metadata=obs,
-                                                   epoch=2000.0)
+                                              obs_metadata=obs,
+                                              epoch=2000.0)
 
         names1 = chipNameFromRaDec(raList, decList,
                                    obs_metadata=obs,
@@ -86,7 +84,6 @@ class ChipNameTest(unittest.TestCase):
 
         self.assertGreater(isNotNone, 0)
 
-
     def testExceptions(self):
         """
         Test that exceptions are raised when they should be
@@ -103,17 +100,17 @@ class ChipNameTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(xpList, ypList)
         self.assertEqual('No camera defined.  Cannot run chipName.',
-                          context.exception.message)
+                         context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
         self.assertEqual('No camera defined.  Cannot run chipName.',
-                          context.exception.message)
+                         context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, obs_metadata=obs, epoch=2000.0)
         self.assertEqual('No camera defined.  Cannot run chipName.',
-                          context.exception.message)
+                         context.exception.message)
 
         # verify that an exception is raised if you do not pass in a numpy array
         with self.assertRaises(RuntimeError) as context:
@@ -141,21 +138,25 @@ class ChipNameTest(unittest.TestCase):
         # verify that an exception is raised if the two coordinate arrays contain
         # different numbers of elements
         xpDummy = np.random.random_sample(nStars/2)
+
         with self.assertRaises(RuntimeError) as context:
             chipNameFromPupilCoords(xpDummy, ypList, camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          "The arrays input to chipNameFromPupilCoords all need "
                          "to have the same length")
 
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
-                                  camera=self.camera)
+                              camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          "The arrays input to chipNameFromRaDec all need to have the same length")
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpDummy, ypList, obs_metadata=obs, epoch=2000.0,
-                                   camera=self.camera)
+                               camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          "The arrays input to chipNameFromRaDec all need to have the same length")
 
@@ -163,11 +164,13 @@ class ChipNameTest(unittest.TestCase):
         # without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData into chipName')
 
@@ -175,15 +178,18 @@ class ChipNameTest(unittest.TestCase):
         # with an ObservationMetaData that has no mjd
         obsDummy = ObservationMetaData(pointingRA=25.0, pointingDec=-112.0,
                                        rotSkyPos=112.0)
+
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
-                                  camera=self.camera)
+                              camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData with an mjd into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
-                                  camera=self.camera)
+                               camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData with an mjd into chipName')
 
@@ -191,18 +197,20 @@ class ChipNameTest(unittest.TestCase):
         # using an ObservationMetaData without a rotSkyPos
         obsDummy = ObservationMetaData(pointingRA=25.0, pointingDec=-112.0,
                                        mjd=52350.0)
+
         with self.assertRaises(RuntimeError) as context:
             chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
-                                  camera=self.camera)
+                              camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData with a rotSkyPos into chipName')
 
         with self.assertRaises(RuntimeError) as context:
             _chipNameFromRaDec(xpList, ypList, epoch=2000.0, obs_metadata=obsDummy,
-                                  camera=self.camera)
+                               camera=self.camera)
+
         self.assertEqual(context.exception.message,
                          'You need to pass an ObservationMetaData with a rotSkyPos into chipName')
-
 
     def testNaNbecomesNone(self):
         """
@@ -212,7 +220,7 @@ class ChipNameTest(unittest.TestCase):
         nStars = 100
         ra0 = 45.0
         dec0 = -112.0
-        rotSkyPos=135.0
+        rotSkyPos = 135.0
         mjd = 42350.0
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=mjd, rotSkyPos=rotSkyPos)
@@ -232,10 +240,10 @@ class ChipNameTest(unittest.TestCase):
                                                   epoch=2000.0)
 
             names1 = chipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
-                                            camera=self.camera)
+                                       camera=self.camera)
 
             names2 = _chipNameFromRaDec(np.radians(raList), np.radians(decList),
-                                            obs_metadata=obs, epoch=2000.0, camera=self.camera)
+                                        obs_metadata=obs, epoch=2000.0, camera=self.camera)
 
             names3 = chipNameFromPupilCoords(xpList, ypList, camera=self.camera)
 
@@ -252,7 +260,6 @@ class ChipNameTest(unittest.TestCase):
                     self.assertIsNone(names2[ix], None)
                     self.assertIsNone(names3[ix], None)
 
-
     def testPassingFloats(self):
         """
         Test that you can pass floats of RA, Dec into chipNameFromRaDec.
@@ -262,7 +269,7 @@ class ChipNameTest(unittest.TestCase):
 
         ra0 = 45.0
         dec0 = -112.0
-        rotSkyPos=135.0
+        rotSkyPos = 135.0
         mjd = 42350.0
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   mjd=mjd, rotSkyPos=rotSkyPos)
@@ -313,7 +320,6 @@ class PixelCoordTest(unittest.TestCase):
     def setUp(self):
         np.random.seed(11324)
 
-
     def testConsistency(self):
         """
         Test that all of the pixelCoord calculation methods agree with
@@ -357,7 +363,6 @@ class PixelCoordTest(unittest.TestCase):
                                              obs_metadata=obs, epoch=2000.0,
                                              camera=self.camera, includeDistortion=includeDistortion,
                                              chipName=chipNameList)
-
 
             np.testing.assert_array_equal(xx1, xx2)
             np.testing.assert_array_equal(xx1, xx3)
@@ -428,7 +433,6 @@ class PixelCoordTest(unittest.TestCase):
                     self.assertTrue(np.isnan(xx1[ix]))
                     self.assertTrue(np.isnan(yy1[ix]))
 
-
     def testSingleChipName(self):
         """
         Test that pixelCoordsFromRaDec works when a list of RA, Dec are passed in,
@@ -449,7 +453,7 @@ class PixelCoordTest(unittest.TestCase):
                                          camera=self.camera)
 
         chosen_chip = 'Det40'
-        valid_pts = np.where(chipNameList==chosen_chip)[0]
+        valid_pts = np.where(chipNameList == chosen_chip)[0]
         self.assertGreater(len(valid_pts), 1)
         xPixControl, yPixControl = pixelCoordsFromRaDec(raList[valid_pts], decList[valid_pts],
                                                         obs_metadata=obs,
@@ -483,8 +487,8 @@ class PixelCoordTest(unittest.TestCase):
                                                np.radians(decList[valid_pts]),
                                                np.radians(raTest), np.radians(decTest)))
 
-        self.assertLess(distance.max(), 0.004) # because of the imprecision in
-                                               # _icrsFromObserved, this is the best we can do
+        self.assertLess(distance.max(), 0.004)  # because of the imprecision in
+                                                # _icrsFromObserved, this is the best we can do
 
         raTest, decTest = raDecFromPixelCoords(xPixControl, yPixControl, [chosen_chip],
                                                camera=self.camera, obs_metadata=obs,
@@ -495,7 +499,6 @@ class PixelCoordTest(unittest.TestCase):
                                                np.radians(raTest), np.radians(decTest)))
 
         self.assertLess(distance.max(), 0.004)
-
 
     def testExceptions(self):
         """
@@ -517,12 +520,14 @@ class PixelCoordTest(unittest.TestCase):
         # pass in a camera
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList)
+
         self.assertEqual(context.exception.message,
                          'Camera not specified.  Cannot calculate pixel coordinates.')
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList, obs_metadata=obs,
                                  epoch=2000.0)
+
         self.assertEqual(context.exception.message,
                          'Camera not specified.  Cannot calculate pixel coordinates.')
 
@@ -531,20 +536,22 @@ class PixelCoordTest(unittest.TestCase):
                                   np.radians(decList),
                                   obs_metadata=obs,
                                   epoch=2000.0)
+
         self.assertEqual(context.exception.message,
                          'Camera not specified.  Cannot calculate pixel coordinates.')
-
 
         # test that an exception is raised when you pass in something
         # that is not a numpy array
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(list(xpList), ypList,
                                        camera=self.camera)
+
         self.assertIn("The arg xPupil", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, list(ypList),
                                        camera=self.camera)
+
         self.assertIn("The input arguments:", context.exception.args[0])
         self.assertIn("yPupil", context.exception.args[0])
 
@@ -554,6 +561,7 @@ class PixelCoordTest(unittest.TestCase):
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
+
         self.assertIn("The arg ra", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
@@ -562,6 +570,7 @@ class PixelCoordTest(unittest.TestCase):
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
+
         self.assertIn("The input arguments:", context.exception.args[0])
         self.assertIn("dec", context.exception.args[0])
 
@@ -574,6 +583,7 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList[0:10],
                                        camera=self.camera)
+
         self.assertEqual(context.exception.args[0],
                          "The arrays input to pixelCoordsFromPupilCoords "
                          "all need to have the same length")
@@ -583,6 +593,7 @@ class PixelCoordTest(unittest.TestCase):
                                  obs_metadata=obs,
                                  epoch=2000.0,
                                  camera=self.camera)
+
         self.assertEqual(context.exception.args[0],
                          "The arrays input to pixelCoordsFromRaDec all need "
                          "to have the same length")
@@ -593,16 +604,17 @@ class PixelCoordTest(unittest.TestCase):
                                   obs_metadata=obs,
                                   epoch=2000.0,
                                   camera=self.camera)
+
         self.assertEqual(context.exception.args[0],
                          "The arrays input to pixelCoordsFromRaDec all need "
                          "to have the same length")
-
 
         # test that an error is raised if you pass an incorrect
         # number of chipNames to pixelCoordsFromPupilCoords
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList, chipName=['Det22']*10,
-                                 camera=self.camera)
+                                       camera=self.camera)
+
         self.assertIn("You passed 10 chipNames", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
@@ -610,6 +622,7 @@ class PixelCoordTest(unittest.TestCase):
                                  camera=self.camera,
                                  obs_metadata=obs,
                                  epoch=2000.0)
+
         self.assertIn("You passed 10 chipNames", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
@@ -619,61 +632,68 @@ class PixelCoordTest(unittest.TestCase):
                                   camera=self.camera,
                                   obs_metadata=obs,
                                   epoch=2000.0)
-        self.assertIn("You passed 10 chipNames", context.exception.args[0])
 
+        self.assertIn("You passed 10 chipNames", context.exception.args[0])
 
         # test that an exception is raised if you call one of the
         # pixelCoordsFromRaDec methods without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList,
                                  camera=self.camera, epoch=2000.0)
+
         self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData into ' \
-                         + 'pixelCoordsFromRaDec')
+                         'You need to pass an ObservationMetaData into '
+                         'pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(raList, decList,
                                   camera=self.camera, epoch=2000.0)
+
         self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData into ' \
-                         + 'pixelCoordsFromRaDec')
+                         'You need to pass an ObservationMetaData into '
+                         'pixelCoordsFromRaDec')
 
         # test that an exception is raised if you try to use an
         # ObservationMetaData without an mjd
         obsDummy = ObservationMetaData(pointingRA=25.0,
                                        pointingDec=-36.0,
                                        rotSkyPos=112.0)
+
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList,
                                  camera=self.camera,
                                  epoch=2000.0,
                                  obs_metadata=obsDummy)
+
         self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData ' \
-                         + 'with an mjd into pixelCoordsFromRaDec')
+                         'You need to pass an ObservationMetaData '
+                         'with an mjd into pixelCoordsFromRaDec')
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(raList, decList,
                                   camera=self.camera,
                                   epoch=2000.0,
                                   obs_metadata=obsDummy)
+
         self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData ' \
-                         + 'with an mjd into pixelCoordsFromRaDec')
+                         'You need to pass an ObservationMetaData '
+                         'with an mjd into pixelCoordsFromRaDec')
 
         # test that an exception is raised if you try to use an
         # ObservationMetaData without a rotSkyPos
         obsDummy = ObservationMetaData(pointingRA=25.0,
                                        pointingDec=-36.0,
                                        mjd=53000.0)
+
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList,
                                  camera=self.camera,
                                  epoch=2000.0,
                                  obs_metadata=obsDummy)
+
         self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData ' \
-                         + 'with a rotSkyPos into pixelCoordsFromRaDec')
+                         'You need to pass an ObservationMetaData '
+                         'with a rotSkyPos into pixelCoordsFromRaDec')
 
         obsDummy = ObservationMetaData(pointingRA=25.0,
                                        pointingDec=-36.0,
@@ -683,10 +703,10 @@ class PixelCoordTest(unittest.TestCase):
                                   camera=self.camera,
                                   epoch=2000.0,
                                   obs_metadata=obsDummy)
-        self.assertEqual(context.exception.message,
-                         'You need to pass an ObservationMetaData ' \
-                         + 'with a rotSkyPos into pixelCoordsFromRaDec')
 
+        self.assertEqual(context.exception.message,
+                         'You need to pass an ObservationMetaData '
+                         'with a rotSkyPos into pixelCoordsFromRaDec')
 
     def testResults(self):
         """
@@ -706,7 +726,7 @@ class PixelCoordTest(unittest.TestCase):
         arcsecPerPixel = 0.02
         arcsecPerMicron = 0.002
 
-        #list a bunch of detector centers in radians
+        # list a bunch of detector centers in radians
         x22 = 0.0
         y22 = 0.0
 
@@ -779,7 +799,6 @@ class PixelCoordTest(unittest.TestCase):
             self.assertAlmostEqual(xpx_f, xPixTest[ix], 12)
             self.assertAlmostEqual(ypx_f, yPixTest[ix], 12)
 
-
     def testOffChipResults(self):
         """
         Test that the results of the pixelCoords methods make sense in the case
@@ -802,7 +821,7 @@ class PixelCoordTest(unittest.TestCase):
         arcsecPerPixel = 0.02
         arcsecPerMicron = 0.002
 
-        #list a bunch of detector centers in radians
+        # list a bunch of detector centers in radians
         x22 = 0.0
         y22 = 0.0
 
@@ -893,8 +912,6 @@ class PixelCoordTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(xPix_one, xPixTest, 12)
         np.testing.assert_array_almost_equal(yPix_one, yPixTest, 12)
 
-
-
         xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPixTest, yPixTest, 'Det40',
                                                         camera=self.camera,
                                                         includeDistortion=False)
@@ -909,7 +926,6 @@ class PixelCoordTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(xPupTest, xPupList, 12)
         np.testing.assert_array_almost_equal(yPupTest, yPupList, 12)
 
-
     def testNaN(self):
         """
         Verify that NaNs and Nones input to pixelCoordinate calculation methods result
@@ -920,7 +936,6 @@ class PixelCoordTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=ra0, pointingDec=dec0,
                                   rotSkyPos=42.0, mjd=42356.0)
 
-        nStars = 10
         raList = np.random.random_sample(100)*100.0/3600.0 + ra0
         decList = np.random.random_sample(100)*100.0/3600.0 + dec0
         chipNameList = chipNameFromRaDec(raList, decList, obs_metadata=obs, epoch=2000.0,
@@ -999,7 +1014,6 @@ class PixelCoordTest(unittest.TestCase):
                     self.assertAlmostEqual(xx, xpx_f, 12)
                     self.assertAlmostEqual(yy, ypx_f, 12)
 
-
     def testDistortion(self):
         """
         Make sure that the results from pixelCoordsFromPupilCoords are different
@@ -1008,7 +1022,6 @@ class PixelCoordTest(unittest.TestCase):
         Note: This test passes because the test camera has a pincushion distortion.
         If we take that away, the test will no longer pass.
         """
-        nStars = 100
         xp = radiansFromArcsec((np.random.random_sample(100)-0.5)*100.0)
         yp = radiansFromArcsec((np.random.random_sample(100)-0.5)*100.0)
 
@@ -1017,11 +1030,11 @@ class PixelCoordTest(unittest.TestCase):
 
         # just verify that the distorted versus undistorted coordinates vary in the
         # 4th decimal place
-        with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(xu, xd, 4)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_array_almost_equal, xu, xd, 4)
 
-        with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(yu, yd, 4)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_array_almost_equal, yu, yd, 4)
 
         # make sure that distortions are also present when we pass pupil coordinates in
         # one-at-a-time
@@ -1045,7 +1058,6 @@ class FocalPlaneCoordTest(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(8374522)
-
 
     def testConsistency(self):
         """
@@ -1113,7 +1125,6 @@ class FocalPlaneCoordTest(unittest.TestCase):
             self.assertEqual(x_f, xf1[ix])
             self.assertEqual(y_f, yf1[ix])
 
-
     def testExceptions(self):
         """
         Test that the focalPlaneCoord methods raise the exceptions
@@ -1137,25 +1148,26 @@ class FocalPlaneCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromPupilCoords(xPupList, yPupList)
         self.assertEqual(context.exception.message,
-                         "You cannot calculate focal plane coordinates " \
-                         + "without specifying a camera")
+                         "You cannot calculate focal plane coordinates "
+                         "without specifying a camera")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromRaDec(raList, decList,
                                                obs_metadata=obs,
                                                epoch=2000.0)
+
         self.assertEqual(context.exception.message,
-                         "You cannot calculate focal plane coordinates " \
-                         + "without specifying a camera")
+                         "You cannot calculate focal plane coordinates "
+                         "without specifying a camera")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, decList,
                                                 obs_metadata=obs,
                                                 epoch=2000.0)
-        self.assertEqual(context.exception.message,
-                         "You cannot calculate focal plane coordinates " \
-                         + "without specifying a camera")
 
+        self.assertEqual(context.exception.message,
+                         "You cannot calculate focal plane coordinates "
+                         "without specifying a camera")
 
         # test that an error is raised when you pass in something that
         # is not a numpy array
@@ -1216,25 +1228,24 @@ class FocalPlaneCoordTest(unittest.TestCase):
                          "The arrays input to focalPlaneCoordsFromRaDec "
                          "all need to have the same length")
 
-
         # test that an error is raised if you call
         # focalPlaneCoordsFromRaDec without an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
             xf, yf = focalPlaneCoordsFromRaDec(raList, decList,
                                                epoch=2000.0,
                                                camera=self.camera)
+
         self.assertEqual(context.exception.message,
-                         "You have to specify an ObservationMetaData to run " \
-                         + "focalPlaneCoordsFromRaDec")
+                         "You have to specify an ObservationMetaData to run "
+                         "focalPlaneCoordsFromRaDec")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, decList,
                                                 epoch=2000.0,
                                                 camera=self.camera)
         self.assertEqual(context.exception.message,
-                         "You have to specify an ObservationMetaData to run " \
-                         + "focalPlaneCoordsFromRaDec")
-
+                         "You have to specify an ObservationMetaData to run "
+                         "focalPlaneCoordsFromRaDec")
 
         # test that an error is raised if you pass an ObservationMetaData
         # without an mjd into focalPlaneCoordsFromRaDec
@@ -1246,17 +1257,18 @@ class FocalPlaneCoordTest(unittest.TestCase):
                                                epoch=2000.0,
                                                camera=self.camera)
         self.assertEqual(context.exception.message,
-                         "You need to pass an ObservationMetaData with an " \
-                         + "mjd into focalPlaneCoordsFromRaDec")
+                         "You need to pass an ObservationMetaData with an "
+                         "mjd into focalPlaneCoordsFromRaDec")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, decList,
                                                 obs_metadata=obsDummy,
                                                 epoch=2000.0,
                                                 camera=self.camera)
+
         self.assertEqual(context.exception.message,
-                         "You need to pass an ObservationMetaData with an " \
-                         + "mjd into focalPlaneCoordsFromRaDec")
+                         "You need to pass an ObservationMetaData with an "
+                         "mjd into focalPlaneCoordsFromRaDec")
 
         # test that an error is raised if you pass an ObservationMetaData
         # without a rotSkyPos into focalPlaneCoordsFromRaDec
@@ -1267,9 +1279,10 @@ class FocalPlaneCoordTest(unittest.TestCase):
                                                obs_metadata=obsDummy,
                                                epoch=2000.0,
                                                camera=self.camera)
+
         self.assertEqual(context.exception.message,
-                         "You need to pass an ObservationMetaData with a " \
-                         + "rotSkyPos into focalPlaneCoordsFromRaDec")
+                         "You need to pass an ObservationMetaData with a "
+                         "rotSkyPos into focalPlaneCoordsFromRaDec")
 
         with self.assertRaises(RuntimeError) as context:
             xf, yf = _focalPlaneCoordsFromRaDec(raList, decList,
@@ -1277,9 +1290,8 @@ class FocalPlaneCoordTest(unittest.TestCase):
                                                 epoch=2000.0,
                                                 camera=self.camera)
         self.assertEqual(context.exception.message,
-                         "You need to pass an ObservationMetaData with a " \
-                         + "rotSkyPos into focalPlaneCoordsFromRaDec")
-
+                         "You need to pass an ObservationMetaData with a "
+                         "rotSkyPos into focalPlaneCoordsFromRaDec")
 
     def testResults(self):
         """
@@ -1302,7 +1314,7 @@ class FocalPlaneCoordTest(unittest.TestCase):
         arcsecPerMicron = 0.002
         mmPerArcsec = 0.5
 
-        #list a bunch of detector centers in radians
+        # list a bunch of detector centers in radians
         x22 = 0.0
         y22 = 0.0
 
@@ -1379,9 +1391,8 @@ class ConversionFromPixelTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPix, yPix, chipNameList)
         self.assertEqual(context.exception.message,
-                         "You cannot call pupilCoordsFromPixelCoords without specifying " \
-                         + "a camera")
-
+                         "You cannot call pupilCoordsFromPixelCoords without specifying "
+                         "a camera")
 
     def testPupCoordsResults(self):
         """
@@ -1421,7 +1432,6 @@ class ConversionFromPixelTest(unittest.TestCase):
                 self.assertAlmostEqual(xp_f, xPupTest[ix], 12)
                 self.assertAlmostEqual(yp_f, yPupTest[ix], 12)
 
-
     def testPupCoordsNaN(self):
         """
         Test that points which do not have a chip return NaN for pupilCoordsFromPixelCoords
@@ -1435,7 +1445,6 @@ class ConversionFromPixelTest(unittest.TestCase):
         xPupTest, yPupTest = pupilCoordsFromPixelCoords(xPix, yPix, chipNameList, camera=self.camera)
         self.assertTrue(np.isnan(xPupTest[5]))
         self.assertTrue(np.isnan(yPupTest[5]))
-
 
     def testRaDecExceptions(self):
         """
@@ -1465,7 +1474,6 @@ class ConversionFromPixelTest(unittest.TestCase):
                                             obs_metadata=obs, epoch=2000.0)
         self.assertEqual(context.exception.message,
                          "You cannot call raDecFromPixelCoords without specifying a camera")
-
 
         # test that an error is raised if you do not pass in an ObservationMetaData
         with self.assertRaises(RuntimeError) as context:
@@ -1498,7 +1506,6 @@ class ConversionFromPixelTest(unittest.TestCase):
         self.assertEqual(context.exception.message,
                          "The ObservationMetaData in raDecFromPixelCoords must have an mjd")
 
-
         # test that an error is raised if you pass in an ObservationMetaData
         # without a rotSkyPos
         obsDummy = ObservationMetaData(pointingRA=ra0, pointingDec=dec0, mjd=43243.0)
@@ -1515,7 +1522,6 @@ class ConversionFromPixelTest(unittest.TestCase):
                                             epoch=2000.0, camera=self.camera)
         self.assertEqual(context.exception.message,
                          "The ObservationMetaData in raDecFromPixelCoords must have a rotSkyPos")
-
 
         # test that an error is raised if you pass in lists of pixel coordinates,
         # rather than numpy arrays
@@ -1571,8 +1577,6 @@ class ConversionFromPixelTest(unittest.TestCase):
                                             obs_metadata=obs, epoch=2000.0, camera=self.camera)
         self.assertIn("22 chipNames", context.exception.args[0])
 
-
-
     def testResults(self):
         """
         Test that raDecFromPixelCoords results are consistent with
@@ -1596,11 +1600,9 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                  epoch=2000.0, camera=self.camera,
                                                  includeDistortion=includeDistortion)
 
-
             raRad, decRad = _raDecFromPixelCoords(xPixList, yPixList, chipNameList, obs_metadata=obs,
                                                   epoch=2000.0, camera=self.camera,
                                                   includeDistortion=includeDistortion)
-
 
             # first, make sure that the radians and degrees methods agree with each other
             dRa = arcsecFromRadians(raRad-np.radians(raDeg))
@@ -1616,12 +1618,12 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                       epoch=2000.0, camera=self.camera,
                                                       includeDistortion=includeDistortion)
 
-
-            distance = np.sqrt(np.power(xPixTest-xPixList,2)+np.power(yPixTest-yPixList,2))
-            self.assertLess(distance.max(),0.2) # because of the imprecision in _icrsFromObserved, this is the best
-                                                # we can get; note that, in our test camera, each pixel is 10 microns
-                                                # in size and the plate scale is 2 arcsec per mm, so 0.2 pixels is
-                                                # 0.004 arcsec
+            distance = np.sqrt(np.power(xPixTest-xPixList, 2) + np.power(yPixTest-yPixList, 2))
+            self.assertLess(distance.max(), 0.2)  # because of the imprecision in _icrsFromObserved,
+                                                  # this is the best we can get; note that, in our test
+                                                  # camera, each pixel is 10 microns in size and the
+                                                  # plate scale is 2 arcsec per mm, so 0.2 pixels is
+                                                  # 0.004 arcsec
 
             # test passing the pixel coordinates in one at a time
             for ix in range(len(xPixList)):
@@ -1633,7 +1635,6 @@ class ConversionFromPixelTest(unittest.TestCase):
                 self.assertIsInstance(dec_f, np.float)
                 self.assertAlmostEqual(ra_f, raDeg[ix], 12)
                 self.assertAlmostEqual(dec_f, decDeg[ix], 12)
-
 
     def testResultsOffChip(self):
         """
@@ -1662,11 +1663,9 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                  epoch=2000.0, camera=self.camera,
                                                  includeDistortion=includeDistortion)
 
-
             raRad, decRad = _raDecFromPixelCoords(xPixList, yPixList, chipNameList, obs_metadata=obs,
                                                   epoch=2000.0, camera=self.camera,
                                                   includeDistortion=includeDistortion)
-
 
             # first, make sure that the radians and degrees methods agree with each other
             dRa = arcsecFromRadians(raRad-np.radians(raDeg))
@@ -1684,14 +1683,12 @@ class ConversionFromPixelTest(unittest.TestCase):
                                                       camera=self.camera,
                                                       includeDistortion=includeDistortion)
 
-
-            distance = np.sqrt(np.power(xPixTest-xPixList,2)+np.power(yPixTest-yPixList,2))
-            self.assertLess(distance.max(),0.2) # because of the imprecision in _icrsFromObserved, this is the best
-                                                # we can get; note that, in our test camera, each pixel is 10 microns
-                                                # in size and the plate scale is 2 arcsec per mm, so 0.2 pixels is
-                                                # 0.004 arcsec
-
-
+            distance = np.sqrt(np.power(xPixTest-xPixList, 2) + np.power(yPixTest-yPixList, 2))
+            self.assertLess(distance.max(), 0.2)  # because of the imprecision in _icrsFromObserved,
+                                                  # this is the best we can get; note that, in our
+                                                  # test camera, each pixel is 10 microns in size and
+                                                  # the plate scale is 2 arcsec per mm, so 0.2 pixels is
+                                                  # 0.004 arcsec
 
     def testDistortion(self):
         """
@@ -1715,11 +1712,17 @@ class ConversionFromPixelTest(unittest.TestCase):
                                             includeDistortion=True)
 
         # just verify that the distorted versus undistorted coordinates vary in the 4th decimal
-        with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(arcsecFromRadians(xu), arcsecFromRadians(xd), 4)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_array_almost_equal,
+                          arcsecFromRadians(xu),
+                          arcsecFromRadians(xd),
+                          4)
 
-        with self.assertRaises(AssertionError) as context:
-            np.testing.assert_array_almost_equal(arcsecFromRadians(yu), arcsecFromRadians(yd), 4)
+        self.assertRaises(AssertionError,
+                          np.testing.assert_array_almost_equal,
+                          arcsecFromRadians(yu),
+                          arcsecFromRadians(yd),
+                          4)
 
 
 class CornerTest(unittest.TestCase):
@@ -1729,7 +1732,6 @@ class CornerTest(unittest.TestCase):
         cameraDir = getPackageDir('sims_coordUtils')
         cameraDir = os.path.join(cameraDir, 'tests', 'cameraData')
         cls.camera = ReturnCamera(cameraDir)
-
 
     def testCornerPixels(self):
         """
@@ -1747,7 +1749,6 @@ class CornerTest(unittest.TestCase):
         self.assertEqual(corners[3][0], 3999)
         self.assertEqual(corners[3][1], 3999)
         self.assertEqual(len(corners), 4)
-
 
     def testCornerRaDec_radians(self):
         """
@@ -1777,7 +1778,6 @@ class CornerTest(unittest.TestCase):
             dd = haversine(rr1, dd1, cc[0], cc[1])
             self.assertLess(arcsecFromRadians(dd), 0.00001)
 
-
     def testCornerRaDec_degrees(self):
         """
         Test that method to get corner RA, Dec in degrees is consistent
@@ -1806,8 +1806,9 @@ def suite():
     suites += unittest.makeSuite(CornerTest)
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit=False):
-    utilsTests.run(suite(),shouldExit)
+    utilsTests.run(suite(), shouldExit)
 
 if __name__ == "__main__":
     run(True)

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -26,6 +26,8 @@ from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
 
 from lsst.sims.coordUtils import raDecFromPixelCoords, _raDecFromPixelCoords
 
+from lsst.sims.coordUtils import getCornerPixels
+
 class ChipNameTest(unittest.TestCase):
 
     @classmethod
@@ -279,6 +281,23 @@ class PixelCoordTest(unittest.TestCase):
 
     def setUp(self):
         numpy.random.seed(11324)
+
+    def testCornerPixels(self):
+        """
+        Test the method to get the pixel coordinates of the corner
+        of a detector
+        """
+        det_name = self.camera[0].getName()
+        corners = getCornerPixels(det_name, self.camera)
+        self.assertEqual(corners[0][0], 0)
+        self.assertEqual(corners[0][1], 0)
+        self.assertEqual(corners[1][0], 0)
+        self.assertEqual(corners[1][1], 3999)
+        self.assertEqual(corners[2][0], 3999)
+        self.assertEqual(corners[2][1], 0)
+        self.assertEqual(corners[3][0], 3999)
+        self.assertEqual(corners[3][1], 3999)
+        self.assertEqual(len(corners), 4)
 
 
     def testConsistency(self):

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -581,16 +581,14 @@ class PixelCoordTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromPupilCoords(xpList, ypList, chipNames=['Det22']*10,
                                  camera=self.camera)
-        self.assertEqual(context.exception.message,
-                         'You passed 100 points but 10 chipNames to pixelCoordsFromPupilCoords')
+        self.assertIn("You only passed 10 chipNames", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             pixelCoordsFromRaDec(raList, decList, chipNames=['Det22']*10,
                                  camera=self.camera,
                                  obs_metadata=obs,
                                  epoch=2000.0)
-        self.assertEqual(context.exception.message,
-                         'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
+        self.assertIn("You only passed 10 chipNames", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             _pixelCoordsFromRaDec(np.radians(raList),
@@ -599,8 +597,7 @@ class PixelCoordTest(unittest.TestCase):
                                   camera=self.camera,
                                   obs_metadata=obs,
                                   epoch=2000.0)
-        self.assertEqual(context.exception.message,
-                         'You passed 100 points but 10 chipNames to pixelCoordsFromRaDec')
+        self.assertIn("You only passed 10 chipNames", context.exception.args[0])
 
 
         # test that an exception is raised if you call one of the

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -22,9 +22,7 @@ from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoords, \
                                  _focalPlaneCoordsFromRaDec
 
 from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
-
 from lsst.sims.coordUtils import raDecFromPixelCoords, _raDecFromPixelCoords
-
 from lsst.sims.coordUtils import getCornerPixels, _getCornerRaDec, getCornerRaDec
 
 


### PR DESCRIPTION
This pull request incorporates the methods I drew up for the camera team to find the coordinates of the corners of specific chips into sims_coordUtils.  I took the opportunity to clean up a few things about the sims_coordUtils and sims_utils API.  Namely: there were several coordinate transformation methods that could only accept numpy arrays as inputs.  They could not accept single floats.  I fixed those methods so that they can accept either numpy arrays or floats.  I also standardized the names of args in the methods defined in sims_coordUtils/CameraUtils.py.

Like any good pull request, this had implications beyond sims_coordUtils.  There are pull requests in
sims_utils
sims_coordUtils
sims_catUtils
and sims_GalSimInterface
all of which must be built together.
