### PR TITLE
U/danielsf/speed up chipname

### DIFF
--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -322,7 +322,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                                            "to pixel coordinates) you can try re-running with " +
                                            "the kwarg allow_multiple_chips=True.\n" +
                                            "Chip names were %s\n" % str(name_list) +
-                                           "Pupil coordinat point was %.12f %.12f\n" % (pt[0], pt[1]))
+                                           "Pupil coordinate point was %.12f %.12f\n" % (pt[0], pt[1]))
 
                 chipNames.append('%s' % str(name_list))
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -322,7 +322,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     chipNames.append(str(name_list))
                 else:
                     warnings.warn("And object has landed on multiple chips.  You asked for this not to happen.\n" +
-                                  "We will return only one of the chip names.  If you want both," +
+                                  "We will return only one of the chip names.  If you want both, " +
                                   "try re-running with " +
                                   "the kwarg allow_multiple_chips=True.\n" +
                                   "Offending chip names were %s\n" % str(name_list) +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -507,7 +507,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
         xPix = []
         yPix = []
         for name, x, y in zip(chipNameList, xPupil, yPupil):
-            if not name:
+            if name is None:
                 xPix.append(np.nan)
                 yPix.append(np.nan)
                 continue
@@ -519,7 +519,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
             yPix.append(detPoint.getPoint().getY())
         return np.array([xPix, yPix])
     else:
-        if not chipNameList[0]:
+        if chipNameList[0] is None:
             return np.array([np.NaN, np.NaN])
 
         cp = camera.makeCameraPoint(afwGeom.Point2D(xPupil, yPupil), PUPIL)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -311,7 +311,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     # we will permit it.
                     #
                     # See figure 2 of arXiv:1506.04839v2
-                    if dd.getType() != WAVEFRONT:
+                    if dd.getType() == WAVEFRONT:
                         n_wavefront += 1
                         break
 

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -11,7 +11,8 @@ __all__ = ["MultipleChipWarning", "getCornerPixels", "_getCornerRaDec", "getCorn
            "pixelCoordsFromPupilCoords", "pixelCoordsFromRaDec", "_pixelCoordsFromRaDec",
            "focalPlaneCoordsFromPupilCoords", "focalPlaneCoordsFromRaDec", "_focalPlaneCoordsFromRaDec",
            "pupilCoordsFromPixelCoords",
-           "raDecFromPixelCoords", "_raDecFromPixelCoords"]
+           "raDecFromPixelCoords", "_raDecFromPixelCoords",
+           "_validate_inputs_and_chipname"]
 
 
 class MultipleChipWarning(Warning):

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -193,7 +193,7 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
                       epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
-    either (xPupil, yPupil).
+    (RA, Dec).
 
     @param [in] ra in degrees (a numpy array or a float).
     In the International Celestial Reference System.
@@ -226,7 +226,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
                        epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
-    either (xPupil, yPupil).
+    (RA, Dec).
 
     @param [in] ra in radians (a numpy array or a float).
     In the International Celestial Reference System.
@@ -271,7 +271,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
 def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
-    either (xPupil, yPupil).
+    (xPupil, yPupil).
 
     @param [in] xPupil is the x pupil coordinate in radians.
     Can be either a float or a numpy array.

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -328,7 +328,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                                   "Offending pupil coordinate point was %.12f %.12f\n" % (pt[0], pt[1]),
                                   category=MultipleChipWarning)
 
-                chipNames.append(name_list[0])
+                    chipNames.append(name_list[0])
 
             elif len(name_list) == 0:
                 chipNames.append(None)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -504,6 +504,7 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
             chipNameList = [chipNameList]
 
     if are_arrays:
+        det_sys_dict = {}
         xPix = []
         yPix = []
         for name, x, y in zip(chipNameList, xPupil, yPupil):
@@ -512,9 +513,11 @@ def pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=None,
                 yPix.append(np.nan)
                 continue
             cp = camera.makeCameraPoint(afwGeom.Point2D(x, y), PUPIL)
-            det = camera[name]
-            cs = det.makeCameraSys(pixelType)
-            detPoint = camera.transform(cp, cs)
+            if name not in det_sys_dict:
+                det = camera[name]
+                cs = det.makeCameraSys(pixelType)
+                det_sys_dict[name] = cs
+            detPoint = camera.transform(cp, det_sys_dict[name])
             xPix.append(detPoint.getPoint().getX())
             yPix.append(detPoint.getPoint().getY())
         return np.array([xPix, yPix])

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -324,7 +324,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                                            "Chip names were %s\n" % str(name_list) +
                                            "Pupil coordinate point was %.12f %.12f\n" % (pt[0], pt[1]))
 
-                chipNames.append('%s' % str(name_list))
+                chipNames.append(name_list)
 
             elif len(name_list) == 0:
                 chipNames.append(None)

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -2,7 +2,6 @@ import numpy as np
 import warnings
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
-from lsst.afw.cameraGeom import WAVEFRONT
 from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.sims.utils import _pupilCoordsFromRaDec, _raDecFromPupilCoords
 
@@ -21,6 +20,7 @@ class MultipleChipWarning(Warning):
     multiple chips are returned.
     """
     pass
+
 
 def _validate_inputs_and_chipname(input_list, input_names, method_name,
                                   chip_name, chipname_can_be_none = True):
@@ -322,7 +322,8 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     # See figure 2 of arXiv:1506.04839v2
                     chipNames.append(str(name_list))
                 else:
-                    warnings.warn("An object has landed on multiple chips.  You asked for this not to happen.\n" +
+                    warnings.warn("An object has landed on multiple chips.  " +
+                                  "You asked for this not to happen.\n" +
                                   "We will return only one of the chip names.  If you want both, " +
                                   "try re-running with " +
                                   "the kwarg allow_multiple_chips=True.\n" +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -312,8 +312,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     # See figure 2 of arXiv:1506.04839v2
                     if dd.getType() != WAVEFRONT:
                         raise RuntimeError("This method does not know how to deal with cameras " +
-                                           "where points can be on multiple detectors.  " +
-                                           "Override CameraCoords.get_chipName to add this.\n" +
+                                           "where points can be on multiple detectors.\n" +
                                            "If you were only asking for the chip name (as opposed " +
                                            "to pixel coordinates) you can try re-running with " +
                                            "the kwarg allow_multiple_chips=True.\n" +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -323,7 +323,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                 else:
                     warnings.warn("And object has landed on multiple chips.  You asked for this not to happen.\n" +
                                   "We will return only one of the chip names.  If you want both," +
-                                  "Try re-running with " +
+                                  "try re-running with " +
                                   "the kwarg allow_multiple_chips=True.\n" +
                                   "Offending chip names were %s\n" % str(name_list) +
                                   "Offending pupil coordinate point was %.12f %.12f\n" % (pt[0], pt[1]),

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -313,13 +313,6 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
             name_list = [dd.getName() for dd in det]
             if len(name_list) > 1:
                 if allow_multiple_chips:
-                    # In the case of LSST, multiple chips are possible
-                    # because each A, B pair of wavefront sensors is positioned so that
-                    # one is in focus and one is out of focus, it is possible that a particular
-                    # RA, Dec could land on both wavefront sensors.  If that is what happened,
-                    # we will permit it.
-                    #
-                    # See figure 2 of arXiv:1506.04839v2
                     chipNames.append(str(name_list))
                 else:
                     warnings.warn("An object has landed on multiple chips.  " +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -303,6 +303,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
         else:
             name_list = [dd.getName() for dd in det]
             if len(name_list) > 1 and not allow_multiple_chips:
+                n_wavefront = 0
                 for dd in det:
                     # Because each A, B pair of wavefront sensors is positioned so that
                     # one is in focus and one is out of focus, it is possible that a particular
@@ -311,6 +312,10 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     #
                     # See figure 2 of arXiv:1506.04839v2
                     if dd.getType() != WAVEFRONT:
+                        n_wavefront += 1
+                        break
+
+                    if n_wavefront == 0:
                         raise RuntimeError("This method does not know how to deal with cameras " +
                                            "where points can be on multiple detectors.\n" +
                                            "If you were only asking for the chip name (as opposed " +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -321,7 +321,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     # See figure 2 of arXiv:1506.04839v2
                     chipNames.append(str(name_list))
                 else:
-                    warnings.warn("And object has landed on multiple chips.  You asked for this not to happen.\n" +
+                    warnings.warn("An object has landed on multiple chips.  You asked for this not to happen.\n" +
                                   "We will return only one of the chip names.  If you want both, " +
                                   "try re-running with " +
                                   "the kwarg allow_multiple_chips=True.\n" +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -193,7 +193,7 @@ def chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
                       epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
-    (RA, Dec).
+    (RA, Dec) in degrees.
 
     @param [in] ra in degrees (a numpy array or a float).
     In the International Celestial Reference System.
@@ -226,7 +226,7 @@ def _chipNameFromRaDec(ra, dec, obs_metadata=None, camera=None,
                        epoch=2000.0, allow_multiple_chips=False):
     """
     Return the names of detectors that see the object specified by
-    (RA, Dec).
+    (RA, Dec)  in radians.
 
     @param [in] ra in radians (a numpy array or a float).
     In the International Celestial Reference System.

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -307,7 +307,9 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                                    "Override CameraCoords.get_chipName to add this.\n" +
                                    "If you were only asking for the chip name (as opposed " +
                                    "to pixel coordinates) you can try re-running with " +
-                                   "the kwarg allow_multiple_chips=True.")
+                                   "the kwarg allow_multiple_chips=True.\n" +
+                                   "Chip names were %s\n" % str(names) +
+                                   "Pupil coordinat point was %.12f %.12f\n" % (pt[0], pt[1]))
             elif len(names) == 0:
                 chipNames.append(None)
             else:

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -322,6 +322,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     chipNames.append(name_list)
                 else:
                     warnings.warn("And object has landed on multiple chips.  You asked for this not to happen.\n" +
+                                  "We will return only one of the chip names.  If you want both," +
                                   "Try re-running with " +
                                   "the kwarg allow_multiple_chips=True.\n" +
                                   "Offending chip names were %s\n" % str(name_list) +

--- a/python/lsst/sims/coordUtils/CameraUtils.py
+++ b/python/lsst/sims/coordUtils/CameraUtils.py
@@ -283,7 +283,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
     this method will allow objects to be visible on more than one chip.  If it is 'False'
     and an object appears on more than one chip, only the first chip will appear in the list of
     chipNames and warning will be emitted.  If it is 'True' and an object falls on more than one
-    chip, a list of chipNames will appear for that object.
+    chip, the resulting chip name will be the string representation of the list of valid chip names.
 
     @param [in] camera is an afwCameraGeom object that specifies the attributes of the camera.
 
@@ -319,7 +319,7 @@ def chipNameFromPupilCoords(xPupil, yPupil, camera=None, allow_multiple_chips=Fa
                     # we will permit it.
                     #
                     # See figure 2 of arXiv:1506.04839v2
-                    chipNames.append(name_list)
+                    chipNames.append(str(name_list))
                 else:
                     warnings.warn("And object has landed on multiple chips.  You asked for this not to happen.\n" +
                                   "We will return only one of the chip names.  If you want both," +

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -124,6 +124,8 @@ def _findDetectorsListLSST(cameraPointList, detectorList, allow_multiple_chips=F
     # wavefront sensors, since adjoining wavefront sensors
     # are kept one in focus, one out of focus.
     # See figure 2 of arXiv:1506.04839v2
+    # (This might actually be a bug in obs_lsstSim
+    # I opened DM-8075 on 25 October 2016 to investigate)
     could_be_multiple = [False]*len(cameraPointList)
     if allow_multiple_chips:
         for ipt in range(len(cameraPointList)):

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -103,7 +103,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList):
     nativePointList = _lsst_camera._transformSingleSysArray(cameraPointList, PUPIL, _lsst_camera._nativeCameraSys)
 
     outputDetList = [None]*len(cameraPointList)
-    outputNameList = ['None']*len(cameraPointList)
+    outputNameList = [None]*len(cameraPointList)
     chip_has_found = np.array([-1]*len(cameraPointList))
     checked_detectors = []
 
@@ -145,7 +145,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList):
                                         outputDetList[ix] = [outputDetList[ix], detector]
                                         outputNameList[ix] = [outputNameList[ix], detector.getName()]
 
-    return outputDetList, outputNameList
+    return np.array(outputDetList), np.array(outputNameList)
 
 
 

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -10,7 +10,7 @@ from lsst.obs.lsstSim import LsstSimMapper
 
 __all__ = ["chipNameFromPupilCoordsLSST",
            "_chipNameFromRaDecLSST", "chipNameFromRaDecLSST",
-           "_pixelCoordsFromRaDecLSST"]
+           "_pixelCoordsFromRaDecLSST", "pixelCoordsFromRaDecLSST"]
 
 _lsst_camera = LsstSimMapper().camera
 
@@ -347,3 +347,47 @@ def _pixelCoordsFromRaDecLSST(ra, dec, obs_metadata=None,
 
     return pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipNameList, camera=_lsst_camera,
                                       includeDistortion=includeDistortion)
+
+def pixelCoordsFromRaDecLSST(ra, dec, obs_metadata=None,
+                             chipName=None, camera=None,
+                             epoch=2000.0, includeDistortion=True):
+    """
+    Get the pixel positions on the LSST camera (or nan if not on a chip) for objects based
+    on their RA, and Dec (in degrees)
+
+    @param [in] ra is in degrees in the International Celestial Reference System.
+    Can be either a float or a numpy array.
+
+    @param [in] dec is in degrees in the International Celestial Reference System.
+    Can be either a float or a numpy array.
+
+    @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+    pointing.
+
+    @param [in] epoch is the epoch in Julian years of the equinox against which
+    RA is measured.  Default is 2000.
+
+    @param [in] chipName designates the names of the chips on which the pixel
+    coordinates will be reckoned.  Can be either single value, an array, or None.
+    If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+    If a single value, all of the pixel coordinates will be reckoned on the same
+    chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+    falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+    chip.  Default is None.
+
+    @param [in] camera is an afwCameraGeom object specifying the attributes of the camera.
+    This is an optional argument to be passed to chipName.
+
+    @param [in] includeDistortion is a boolean.  If True (default), then this method will
+    return the true pixel coordinates with optical distortion included.  If False, this
+    method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+    estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+    details.
+
+    @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+    and the second row is the y pixel coordinate
+    """
+
+    return _pixelCoordsFromRaDecLSST(np.radians(ra), np.radians(dec),
+                                     chipName=chipName, obs_metadata=obs_metadata,
+                                     epoch=2000.0, includeDistortion=includeDistortion)

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -1,0 +1,169 @@
+from __future__ import division
+import numpy as np
+import lsst.afw.geom as afwGeom
+from lsst.afw.cameraGeom import PUPIL, PIXELS
+from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
+from lsst.sims.coordUtils import getCornerPixels
+from lsst.sims.utils.CodeUtilities import _validate_inputs
+from lsst.obs.lsstSim import LsstSimMapper
+
+__all__ = ["chipNameFromPupilCoordsLSST"]
+
+_lsst_camera = LsstSimMapper().camera
+
+_lsst_pupil_coord_map = None
+
+def _build_lsst_pupil_coord_map():
+    """
+    This method populates the global variable _lsst_pupil_coord_map
+    _lsst_pupil_coord_map['name'] contains a list of the names of each chip in the lsst camera
+    _lsst_pupil_coord_map['xx'] contains the x pupil coordinate of the center of each chip
+    _lsst_pupil_coord_map['yy'] contains the y pupil coordinate of the center of each chip
+    _lsst_pupil_coord_map['dp'] contains the radius (in pupil coordinates) of the circle containing each chip
+    """
+    global _lsst_camera
+    global _lsst_pupil_coord_map
+    if _lsst_pupil_coord_map is not None:
+        raise RuntimeError("Calling _build_pupil_coord_map(), "
+                           "but it is already built.")
+
+    name_list = []
+    x_pix_list = []
+    y_pix_list = []
+    n_chips = 0
+    for chip in _lsst_camera:
+        chip_name = chip.getName()
+        n_chips += 1
+        corner_list = getCornerPixels(chip_name, _lsst_camera)
+        for corner in corner_list:
+            x_pix_list.append(corner[0])
+            y_pix_list.append(corner[1])
+            name_list.append(chip_name)
+
+    x_pix_list = np.array(x_pix_list)
+    y_pix_list = np.array(y_pix_list)
+
+    x_pup_list, y_pup_list = pupilCoordsFromPixelCoords(x_pix_list,
+                                                        y_pix_list,
+                                                        name_list,
+                                                        camera=_lsst_camera)
+    center_x = np.zeros(n_chips, dtype=float)
+    center_y = np.zeros(n_chips, dtype=float)
+    extent = np.zeros(n_chips, dtype=float)
+    final_name = []
+    for ix_ct in range(n_chips):
+        ix = ix_ct*4
+        chip_name = name_list[ix]
+        xx = 0.25*(x_pup_list[ix] + x_pup_list[ix+1]
+                   + x_pup_list[ix+2] + x_pup_list[ix+3])
+
+        yy = 0.25*(y_pup_list[ix] + y_pup_list[ix+1]
+                   + y_pup_list[ix+2] + y_pup_list[ix+3])
+
+        dx = 0.25*np.array([np.sqrt(np.power(xx-x_pup_list[ix+ii], 2)
+                                    + np.power(yy-y_pup_list[ix+ii], 2)) for ii in range(4)]).sum()
+
+        center_x[ix_ct] = xx
+        center_y[ix_ct] = yy
+        extent[ix_ct] = dx
+        final_name.append(chip_name)
+
+    final_name = np.array(final_name)
+
+    _lsst_pupil_coord_map = {}
+    _lsst_pupil_coord_map['name'] = final_name
+    _lsst_pupil_coord_map['xx'] = center_x
+    _lsst_pupil_coord_map['yy'] = center_y
+    _lsst_pupil_coord_map['dp'] = extent
+
+
+def _findDetectorsListLSST(cameraPointList, detectorList):
+    """!Find the detectors that cover a list of points specified by x and y coordinates in any system
+
+    This is based one afw.camerGeom.camera.findDetectorsList.  It has been optimized for the LSST
+    camera in the following way:
+
+        - it accepts a limited list of detectors to check in advance (this list should be
+          constructed by comparing the pupil coordinates in question and comparing to the
+          pupil coordinates of the center of each detector)
+
+       - it will stop looping through detectors one it has found one that is correct (the LSST
+         camera does not allow an object to fall on more than one detector)
+
+    @param[in] cameraPointList  a list of cameraPoints in PUPIL coordinates
+    @param[in] detecorList is a list of lists.  Each row contains the detectors that should be searched
+    for the correspdonding cameraPoint
+    @return outputDetList is a numpy array of detectors containing each point
+    @return outputNameList is a numpy array of the names of the detectors
+    """
+
+    global _lsst_camera
+
+    #transform the points to the native coordinate system
+    nativePointList = _lsst_camera._transformSingleSysArray(cameraPointList, PUPIL, _lsst_camera._nativeCameraSys)
+
+    outputDetList = [None]*len(cameraPointList)
+    outputNameList = np.array(['None']*len(cameraPointList), dtype=(str, 100))
+    checked_detectors = []
+
+    for ipt, nativePoint in enumerate(nativePointList):
+        if outputDetList[ipt] is None:
+            for detector in detectorList[ipt]:
+                if detector.getName() not in checked_detectors:
+                    checked_detectors.append(detector.getName())
+                    unfound_pts = np.where(np.char.rfind(outputNameList, 'None')>=0)[0]
+                    if len(unfound_pts) == 0:
+                        return outputDetList, outputNameList
+                    valid_pt_dexes = np.array([ii for ii in unfound_pts if detector in detectorList[ii]])
+                    if len(valid_pt_dexes)>0:
+                        valid_pt_list = [nativePointList[ii] for ii in valid_pt_dexes]
+                        coordMap = detector.getTransformMap()
+                        cameraSys = detector.makeCameraSys(PIXELS)
+                        detectorPointList = coordMap.transform(valid_pt_list, _lsst_camera._nativeCameraSys, cameraSys)
+                        box = afwGeom.Box2D(detector.getBBox())
+                        for ix, pt in zip(valid_pt_dexes, detectorPointList):
+                            if box.contains(pt):
+                                outputDetList[ix] = detector
+                                outputNameList[ix] = detector.getName()
+
+    return outputDetList, outputNameList
+
+
+
+def chipNameFromPupilCoordsLSST(xPupil, yPupil):
+    """
+    Return the names of LSST detectors that see the object specified by
+    either (xPupil, yPupil).
+
+    @param [in] xPupil is the x pupil coordinate in radians.
+    Can be either a float or a numpy array.
+
+    @param [in] yPupil is the y pupil coordinate in radians.
+    Can be either a float or a numpy array.
+
+    @param [out] a numpy array of chip names
+
+    """
+
+    global _lsst_pupil_coord_map
+    if _lsst_pupil_coord_map is None:
+        _build_lsst_pupil_coord_map()
+
+    are_arrays = _validate_inputs([xPupil, yPupil], ['xPupil', 'yPupil'], "chipNameFromPupilCoordsLSST")
+
+    if are_arrays:
+        cameraPointList = [afwGeom.Point2D(x, y) for x, y in zip(xPupil, yPupil)]
+    else:
+        cameraPointList = [afwGeom.Point2D(xPupil, yPupil)]
+
+    valid_detectors = []
+    for xx, yy in zip(xPupil, yPupil):
+        possible_dexes = np.where(np.sqrt(np.power(xx-_lsst_pupil_coord_map['xx'],2)
+                                          + np.power(yy-_lsst_pupil_coord_map['yy'],2))/_lsst_pupil_coord_map['dp']<2.0)
+
+        local_valid = [_lsst_camera[_lsst_pupil_coord_map['name'][ii]] for ii in possible_dexes[0]]
+        valid_detectors.append(local_valid)
+
+    detList, nameList = _findDetectorsListLSST(cameraPointList, valid_detectors)
+
+    return nameList

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -161,7 +161,7 @@ def chipNameFromPupilCoordsLSST(xPupil, yPupil):
     valid_detectors = []
     for xx, yy in zip(xPupil, yPupil):
         possible_dexes = np.where(np.sqrt(np.power(xx-_lsst_pupil_coord_map['xx'],2)
-                                          + np.power(yy-_lsst_pupil_coord_map['yy'],2))/_lsst_pupil_coord_map['dp']<2.0)
+                                          + np.power(yy-_lsst_pupil_coord_map['yy'],2))/_lsst_pupil_coord_map['dp']<1.1)
 
         local_valid = [_lsst_camera[_lsst_pupil_coord_map['name'][ii]] for ii in possible_dexes[0]]
         valid_detectors.append(local_valid)

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -9,7 +9,7 @@ from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.obs.lsstSim import LsstSimMapper
 
 __all__ = ["chipNameFromPupilCoordsLSST",
-           "_chipNameFromRaDecLSST"]
+           "_chipNameFromRaDecLSST", "chipNameFromRaDecLSST"]
 
 _lsst_camera = LsstSimMapper().camera
 
@@ -247,3 +247,32 @@ def _chipNameFromRaDecLSST(ra, dec, obs_metadata=None, epoch=2000.0, allow_multi
 
     xp, yp = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
     return chipNameFromPupilCoordsLSST(xp, yp, allow_multiple_chips=allow_multiple_chips)
+
+
+def chipNameFromRaDecLSST(ra, dec, obs_metadata=None, epoch=2000.0, allow_multiple_chips=False):
+    """
+    Return the names of detectors on the LSST camera that see the object specified by
+    (RA, Dec) in degrees.
+
+    @param [in] ra in degrees (a numpy array or a float).
+    In the International Celestial Reference System.
+
+    @param [in] dec in degrees (a numpy array or a float).
+    In the International Celestial Reference System.
+
+    @param [in] obs_metadata is an ObservationMetaData characterizing the telescope pointing
+
+    @param [in] epoch is the epoch in Julian years of the equinox against which RA and Dec are
+    measured.  Default is 2000.
+
+    @param [in] allow_multiple_chips is a boolean (default False) indicating whether or not
+    this method will allow objects to be visible on more than one chip.  If it is 'False'
+    and an object appears on more than one chip, only the first chip will appear in the list of
+    chipNames but NO WARNING WILL BE EMITTED.  If it is 'True' and an object falls on more than one
+    chip, a list of chipNames will appear for that object.
+
+    @param [out] a numpy array of chip names
+    """
+    return _chipNameFromRaDecLSST(np.radians(ra), np.radians(dec),
+                                  obs_metadata=obs_metadata, epoch=epoch,
+                                  allow_multiple_chips=allow_multiple_chips)

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -2,14 +2,15 @@ from __future__ import division
 import numpy as np
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, WAVEFRONT
-from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
+from lsst.sims.coordUtils import pupilCoordsFromPixelCoords, pixelCoordsFromPupilCoords
 from lsst.sims.utils import _pupilCoordsFromRaDec
-from lsst.sims.coordUtils import getCornerPixels
+from lsst.sims.coordUtils import getCornerPixels, _validate_inputs_and_chipname
 from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.obs.lsstSim import LsstSimMapper
 
 __all__ = ["chipNameFromPupilCoordsLSST",
-           "_chipNameFromRaDecLSST", "chipNameFromRaDecLSST"]
+           "_chipNameFromRaDecLSST", "chipNameFromRaDecLSST",
+           "_pixelCoordsFromRaDecLSST"]
 
 _lsst_camera = LsstSimMapper().camera
 
@@ -276,3 +277,73 @@ def chipNameFromRaDecLSST(ra, dec, obs_metadata=None, epoch=2000.0, allow_multip
     return _chipNameFromRaDecLSST(np.radians(ra), np.radians(dec),
                                   obs_metadata=obs_metadata, epoch=epoch,
                                   allow_multiple_chips=allow_multiple_chips)
+
+
+def _pixelCoordsFromRaDecLSST(ra, dec, obs_metadata=None,
+                              chipName=None, camera=None,
+                              epoch=2000.0, includeDistortion=True):
+    """
+    Get the pixel positions on the LSST camera (or nan if not on a chip) for objects based
+    on their RA, and Dec (in radians)
+
+    @param [in] ra is in radians in the International Celestial Reference System.
+    Can be either a float or a numpy array.
+
+    @param [in] dec is in radians in the International Celestial Reference System.
+    Can be either a float or a numpy array.
+
+    @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+    pointing.
+
+    @param [in] epoch is the epoch in Julian years of the equinox against which
+    RA is measured.  Default is 2000.
+
+    @param [in] chipName designates the names of the chips on which the pixel
+    coordinates will be reckoned.  Can be either single value, an array, or None.
+    If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+    If a single value, all of the pixel coordinates will be reckoned on the same
+    chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+    falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+    chip.  Default is None.
+
+    @param [in] camera is an afwCameraGeom object specifying the attributes of the camera.
+    This is an optional argument to be passed to chipName.
+
+    @param [in] includeDistortion is a boolean.  If True (default), then this method will
+    return the true pixel coordinates with optical distortion included.  If False, this
+    method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+    estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+    details.
+
+    @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+    and the second row is the y pixel coordinate
+    """
+
+    global _lsst_camera
+
+    are_arrays, \
+    chipNameList = _validate_inputs_and_chipname([ra, dec], ['ra', 'dec'],
+                                                 'pixelCoordsFromRaDecLSST',
+                                                 chipName)
+
+    if epoch is None:
+        raise RuntimeError("You need to pass an epoch into pixelCoordsFromRaDec")
+
+    if obs_metadata is None:
+        raise RuntimeError("You need to pass an ObservationMetaData into pixelCoordsFromRaDec")
+
+    if obs_metadata.mjd is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with an mjd into "
+                           "pixelCoordsFromRaDec")
+
+    if obs_metadata.rotSkyPos is None:
+        raise RuntimeError("You need to pass an ObservationMetaData with a rotSkyPos into "
+                           "pixelCoordsFromRaDec")
+
+    xPupil, yPupil = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=epoch)
+
+    if chipNameList is None:
+        chipNameList = chipNameFromPupilCoordsLSST(xPupil, yPupil)
+
+    return pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipNameList, camera=_lsst_camera,
+                                      includeDistortion=includeDistortion)

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -104,6 +104,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList):
 
     outputDetList = [None]*len(cameraPointList)
     outputNameList = np.array(['None']*len(cameraPointList), dtype=(str, 100))
+    chip_has_found = np.array([-1]*len(cameraPointList))
     checked_detectors = []
 
     for ipt, nativePoint in enumerate(nativePointList):
@@ -111,7 +112,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList):
             for detector in detectorList[ipt]:
                 if detector.getName() not in checked_detectors:
                     checked_detectors.append(detector.getName())
-                    unfound_pts = np.where(np.char.rfind(outputNameList, 'None')>=0)[0]
+                    unfound_pts = np.where(chip_has_found<0)[0]
                     if len(unfound_pts) == 0:
                         return outputDetList, outputNameList
                     valid_pt_dexes = np.array([ii for ii in unfound_pts if detector in detectorList[ii]])
@@ -125,6 +126,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList):
                             if box.contains(pt):
                                 outputDetList[ix] = detector
                                 outputNameList[ix] = detector.getName()
+                                chip_has_found[ix] = 1
 
     return outputDetList, outputNameList
 

--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -124,7 +124,7 @@ def _findDetectorsListLSST(cameraPointList, detectorList, allow_multiple_chips=F
                     could_be_multiple[ipt] = True
 
     for ipt, nativePoint in enumerate(nativePointList):
-        if outputNameList[ipt] is None:
+        if chip_has_found[ipt]<0:  # i.e. if we have not yet found this (RA, Dec) pair
             for detector in detectorList[ipt]:
                 if detector.getName() not in checked_detectors:
                     checked_detectors.append(detector.getName())

--- a/python/lsst/sims/coordUtils/__init__.py
+++ b/python/lsst/sims/coordUtils/__init__.py
@@ -1,1 +1,2 @@
 from .CameraUtils import *
+from .LsstCameraUtils import *

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -317,36 +317,6 @@ class ChipNameTest(unittest.TestCase):
 
         self.assertGreater(n_not_none, 50)
 
-    def test_multiple_chips(self):
-        """
-        Test that findChipName handles multiple chips as expected
-        """
-        chipA = 'R:4,0 S:0,2,A'
-        chipB = 'R:4,0 S:0,2,B'
-        camera = LsstSimMapper().camera
-
-        # from past experience, objects that appear at y=0 on
-        # R:4,0 S:0,2,A also appear on R:4,0 S:0,2,B
-        xpup, ypup = pupilCoordsFromPixelCoords(1500.0, 0.0, chipA, camera=camera)
-
-        with warnings.catch_warnings(record=True) as w_list:
-            name = chipNameFromPupilCoords(xpup, ypup, camera=camera,
-                                           allow_multiple_chips=False)
-
-        self.assertEqual(len(w_list), 1)
-        self.assertEqual(w_list[0].category, MultipleChipWarning)
-        self.assertIsInstance(name, str)
-        self.assertTrue(name == chipA or name == chipB,
-                        msg='unexpected chip name: %s' % name)
-
-        with warnings.catch_warnings(record=True) as w_list:
-            name = chipNameFromPupilCoords(xpup, ypup, camera=camera,
-                                           allow_multiple_chips=True)
-
-        self.assertEqual(len(w_list), 0)
-        self.assertIn(chipA, name)
-        self.assertIn(chipB, name)
-
 
 class PixelCoordTest(unittest.TestCase):
 

--- a/tests/testCameraUtils.py
+++ b/tests/testCameraUtils.py
@@ -344,7 +344,6 @@ class ChipNameTest(unittest.TestCase):
                                            allow_multiple_chips=True)
 
         self.assertEqual(len(w_list), 0)
-        self.assertEqual(len(name), 2)
         self.assertIn(chipA, name)
         self.assertIn(chipB, name)
 

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -198,6 +198,18 @@ class ChipNameTestCase(unittest.TestCase):
         np.testing.assert_array_equal(x_pix, x_pix_test)
         np.testing.assert_array_equal(y_pix, y_pix_test)
 
+        # test when we force a chipName
+        x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
+                                             obs_metadata=obs, camera=self.camera)
+        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+
+        x_pix_test, y_pix_test = _pixelCoordsFromRaDecLSST(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
+                                                           obs_metadata=obs)
+        np.testing.assert_array_equal(x_pix, x_pix_test)
+        np.testing.assert_array_equal(y_pix, y_pix_test)
+
+
         # test without distortion
         x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
                                              includeDistortion=False)

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -58,30 +58,6 @@ class ChipNameTestCase(unittest.TestCase):
             self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None') >= 0)[0]),
                                  n_obj/10)
 
-    def test_multiple_chip_names(self):
-        """
-        Test that chipNameFromPupilCoordsLSST behaves as expected when
-        objects fall on more than one chip (as they could with the
-        wavefront sensors).
-        """
-        chipA = 'R:4,0 S:0,2,A'
-        chipB = 'R:4,0 S:0,2,B'
-
-        # from past experience, objects that appear at y=0 on
-        # R:4,0 S:0,2,A also appear on R:4,0 S:0,2,B
-        xpup, ypup = pupilCoordsFromPixelCoords(1500.0, 0.0, chipA, camera=self.camera)
-        xpup_list = np.array([0.0, xpup])
-        ypup_list = np.array([0.0, ypup])
-        name = chipNameFromPupilCoordsLSST(xpup_list, ypup_list, allow_multiple_chips=False)
-        self.assertIsInstance(name[1], str)
-        self.assertTrue(name[1] == chipA or name[1] == chipB,
-                        msg = 'got unexpected chip name %s' % name)
-
-        name = chipNameFromPupilCoordsLSST(xpup_list, ypup_list, allow_multiple_chips=True)
-        self.assertIn(chipA, name[1])
-        self.assertIn(chipB, name[1])
-        self.assertIsInstance(name[0], str)
-
     def test_chip_name_from_ra_dec_radians(self):
         """
         test that _chipNameFromRaDecLSST agrees with _chipNameFromRaDec

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -209,6 +209,26 @@ class ChipNameTestCase(unittest.TestCase):
         np.testing.assert_array_equal(x_pix, x_pix_test)
         np.testing.assert_array_equal(y_pix, y_pix_test)
 
+        # test that exceptions are raised when incomplete ObservationMetaData are used
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+        self.assertIn("rotSkyPos", context.exception.message)
+
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+        self.assertIn("mjd", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list)
+        self.assertIn("ObservationMetaData", context.exception.message)
+
+        # check that exceptions are raised when ra_list, dec_list are of the wrong shape
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+        self.assertIn("pixelCoordsFromRaDecLSST", context.exception.message)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -34,7 +34,7 @@ class ChipNameTestCase(unittest.TestCase):
         results as chipNameFromPupilCoords
         """
         n_pointings = 3
-        n_obj = 5000
+        n_obj = 1000
         rng = np.random.RandomState(8831)
         ra_pointing_list = rng.random_sample(n_pointings)*360.0
         dec_pointing_list = rng.random_sample(n_pointings)*180.0-90.0
@@ -55,7 +55,7 @@ class ChipNameTestCase(unittest.TestCase):
             np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
 
             # make sure we didn't accidentally get a lot of positions that don't land on chips
-            self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+            self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
 
     def test_multiple_chip_names(self):
         """
@@ -86,7 +86,7 @@ class ChipNameTestCase(unittest.TestCase):
         test that _chipNameFromRaDecLSST agrees with _chipNameFromRaDec
         """
 
-        n_obj = 5000
+        n_obj = 1000
         raP = 112.1
         decP = -34.1
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP,
@@ -105,7 +105,7 @@ class ChipNameTestCase(unittest.TestCase):
                                                 obs_metadata=obs)
 
         np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
-        self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
 
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
@@ -133,7 +133,7 @@ class ChipNameTestCase(unittest.TestCase):
         test that chipNameFromRaDecLSST agrees with chipNameFromRaDec
         """
 
-        n_obj = 5000
+        n_obj = 1000
         raP = 112.1
         decP = -34.1
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP,
@@ -152,7 +152,7 @@ class ChipNameTestCase(unittest.TestCase):
                                                obs_metadata=obs)
 
         np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
-        self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
 
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
@@ -184,15 +184,15 @@ class ChipNameTestCase(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP,
                                   rotSkyPos=13.0, mjd=43441.0)
 
-        n_obj = 5000
+        n_obj = 1000
         rng = np.random.RandomState(83241)
         rr = rng.random_sample(n_obj)*1.75
         theta = rng.random_sample(n_obj)*2.0*np.pi
         ra_list = np.radians(raP + rr*np.cos(theta))
         dec_list = np.radians(decP + rr*np.sin(theta))
         x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         np.testing.assert_array_equal(x_pix, x_pix_test)
@@ -201,8 +201,8 @@ class ChipNameTestCase(unittest.TestCase):
         # test when we force a chipName
         x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
                                              obs_metadata=obs, camera=self.camera)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = _pixelCoordsFromRaDecLSST(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
                                                            obs_metadata=obs)
@@ -213,8 +213,8 @@ class ChipNameTestCase(unittest.TestCase):
         # test without distortion
         x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
                                              includeDistortion=False)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs,
                                                            includeDistortion=False)
@@ -251,15 +251,15 @@ class ChipNameTestCase(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP,
                                   rotSkyPos=13.0, mjd=43441.0)
 
-        n_obj = 5000
+        n_obj = 1000
         rng = np.random.RandomState(83241)
         rr = rng.random_sample(n_obj)*1.75
         theta = rng.random_sample(n_obj)*2.0*np.pi
         ra_list = raP + rr*np.cos(theta)
         dec_list = decP + rr*np.sin(theta)
         x_pix, y_pix = pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         np.testing.assert_array_equal(x_pix, x_pix_test)
@@ -268,8 +268,8 @@ class ChipNameTestCase(unittest.TestCase):
         # test when we force a chipName
         x_pix, y_pix = pixelCoordsFromRaDec(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
                                             obs_metadata=obs, camera=self.camera)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = pixelCoordsFromRaDecLSST(ra_list, dec_list, chipName=['R:2,2 S:1,1'],
                                                           obs_metadata=obs)
@@ -280,8 +280,8 @@ class ChipNameTestCase(unittest.TestCase):
         # test without distortion
         x_pix, y_pix = pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
                                             includeDistortion=False)
-        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
-        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
 
         x_pix_test, y_pix_test = pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs,
                                                           includeDistortion=False)

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -39,10 +39,10 @@ class ChipNameTestCase(unittest.TestCase):
 
             control_name_list = chipNameFromPupilCoords(x_pup, y_pup, camera=camera)
             test_name_list = chipNameFromPupilCoordsLSST(x_pup, y_pup)
-            np.testing.assert_array_equal(control_name_list.astype(str), test_name_list)
+            np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
 
             # make sure we didn't accidentally get a lot of positions that don't land on chips
-            self.assertLess(len(np.where(np.char.rfind(test_name_list, 'None')>=0)[0]), n_obj/10)
+            self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -31,7 +31,7 @@ class ChipNameTestCase(unittest.TestCase):
         results as chipNameFromPupilCoords
         """
         n_pointings = 3
-        n_obj = 10000
+        n_obj = 5000
         rng = np.random.RandomState(8831)
         ra_pointing_list = rng.random_sample(n_pointings)*360.0
         dec_pointing_list = rng.random_sample(n_pointings)*180.0-90.0

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -2,7 +2,8 @@ import unittest
 import numpy as np
 import lsst.utils.tests
 from lsst.sims.coordUtils import (chipNameFromPupilCoords,
-                                  chipNameFromPupilCoordsLSST)
+                                  chipNameFromPupilCoordsLSST,
+                                  pupilCoordsFromPixelCoords)
 from lsst.sims.utils import pupilCoordsFromRaDec
 from lsst.sims.utils import ObservationMetaData
 from lsst.obs.lsstSim import LsstSimMapper
@@ -14,12 +15,19 @@ def setup_module(module):
 
 class ChipNameTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.camera = LsstSimMapper().camera
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.camera
+
     def test_chip_name_from_pupil_coords(self):
         """
         Test that chipNameFromPupilCoordsLSST returns the same
         results as chipNameFromPupilCoords
         """
-        camera = LsstSimMapper().camera
         n_pointings = 3
         n_obj = 10000
         rng = np.random.RandomState(8831)
@@ -37,13 +45,36 @@ class ChipNameTestCase(unittest.TestCase):
             x_pup, y_pup = pupilCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs,
                                                 epoch=2000.0)
 
-            control_name_list = chipNameFromPupilCoords(x_pup, y_pup, camera=camera)
+            control_name_list = chipNameFromPupilCoords(x_pup, y_pup, camera=self.camera)
             test_name_list = chipNameFromPupilCoordsLSST(x_pup, y_pup)
             np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
 
             # make sure we didn't accidentally get a lot of positions that don't land on chips
             self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
 
+    def test_multiple_chip_names(self):
+        """
+        Test that chipNameFromPupilCoordsLSST behaves as expected when
+        objects fall on more than one chip (as they could with the
+        wavefront sensors).
+        """
+        chipA = 'R:4,0 S:0,2,A'
+        chipB = 'R:4,0 S:0,2,B'
+
+        # from past experience, objects that appear at y=0 on
+        # R:4,0 S:0,2,A also appear on R:4,0 S:0,2,B
+        xpup, ypup = pupilCoordsFromPixelCoords(1500.0, 0.0, chipA, camera=self.camera)
+        xpup_list = np.array([0.0, xpup])
+        ypup_list = np.array([0.0, ypup])
+        name = chipNameFromPupilCoordsLSST(xpup_list, ypup_list, allow_multiple_chips=False)
+        self.assertIsInstance(name[1], str)
+        self.assertTrue(name[1] == chipA or name[1] == chipB,
+                        msg = 'got unexpected chip name %s' % name)
+
+        name = chipNameFromPupilCoordsLSST(xpup_list, ypup_list, allow_multiple_chips=True)
+        self.assertIn(chipA, name[1])
+        self.assertIn(chipB, name[1])
+        self.assertIsInstance(name[0], str)
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -1,0 +1,53 @@
+import unittest
+import numpy as np
+import lsst.utils.tests
+from lsst.sims.coordUtils import (chipNameFromPupilCoords,
+                                  chipNameFromPupilCoordsLSST)
+from lsst.sims.utils import pupilCoordsFromRaDec
+from lsst.sims.utils import ObservationMetaData
+from lsst.obs.lsstSim import LsstSimMapper
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class ChipNameTestCase(unittest.TestCase):
+
+    def test_chip_name_from_pupil_coords(self):
+        """
+        Test that chipNameFromPupilCoordsLSST returns the same
+        results as chipNameFromPupilCoords
+        """
+        camera = LsstSimMapper().camera
+        n_pointings = 3
+        n_obj = 10000
+        rng = np.random.RandomState(8831)
+        ra_pointing_list = rng.random_sample(n_pointings)*360.0
+        dec_pointing_list = rng.random_sample(n_pointings)*180.0-90.0
+        rot_list = rng.random_sample(n_pointings)*360.0
+        mjd_list = rng.random_sample(n_pointings)*3653+59580.0
+        for ra, dec, rot, mjd in zip(ra_pointing_list, dec_pointing_list, rot_list, mjd_list):
+            obs = ObservationMetaData(pointingRA=ra, pointingDec=dec,
+                                      rotSkyPos=rot, mjd=mjd)
+            rr_list = rng.random_sample(n_obj)*1.75
+            theta_list = rng.random_sample(n_obj)*2.0*np.pi
+            ra_list = ra + rr_list*np.cos(theta_list)
+            dec_list = dec + rr_list*np.sin(theta_list)
+            x_pup, y_pup = pupilCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs,
+                                                epoch=2000.0)
+
+            control_name_list = chipNameFromPupilCoords(x_pup, y_pup, camera=camera)
+            test_name_list = chipNameFromPupilCoordsLSST(x_pup, y_pup)
+            np.testing.assert_array_equal(control_name_list.astype(str), test_name_list)
+
+            # make sure we didn't accidentally get a lot of positions that don't land on chips
+            self.assertLess(len(np.where(np.char.rfind(test_name_list, 'None')>=0)[0]), n_obj/10)
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -198,6 +198,18 @@ class ChipNameTestCase(unittest.TestCase):
         np.testing.assert_array_equal(x_pix, x_pix_test)
         np.testing.assert_array_equal(y_pix, y_pix_test)
 
+        # test without distortion
+        x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
+                                             includeDistortion=False)
+        self.assertLess(len(np.where(np.isnan(x_pix))[0]), n_obj/10)
+        self.assertLess(len(np.where(np.isnan(y_pix))[0]), n_obj/10)
+
+        x_pix_test, y_pix_test = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs,
+                                                           includeDistortion=False)
+        np.testing.assert_array_equal(x_pix, x_pix_test)
+        np.testing.assert_array_equal(y_pix, y_pix_test)
+
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import unittest
 import numpy as np
 import lsst.utils.tests
@@ -82,6 +83,7 @@ class ChipNameTestCase(unittest.TestCase):
         """
         test that chipNameFromRaDecLSST agrees with chipNameFromRaDec
         """
+
         n_obj = 5000
         raP = 112.1
         decP = -34.1
@@ -102,6 +104,27 @@ class ChipNameTestCase(unittest.TestCase):
 
         np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
         self.assertLess(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+
+        # test that exceptions are raised when incomplete ObservationMetaData are used
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+        self.assertIn("rotSkyPos", context.exception.message)
+
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+        self.assertIn("mjd", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            name = _chipNameFromRaDecLSST(ra_list, dec_list)
+        self.assertIn("ObservationMetaData", context.exception.message)
+
+        # check that exceptions are raised when ra_list, dec_list are of the wrong shape
+        obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
+        with self.assertRaises(RuntimeError) as context:
+            name = _chipNameFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+        self.assertIn("chipNameFromRaDecLSST", context.exception.message)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -55,7 +55,8 @@ class ChipNameTestCase(unittest.TestCase):
             np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
 
             # make sure we didn't accidentally get a lot of positions that don't land on chips
-            self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+            self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None') >= 0)[0]),
+                                 n_obj/10)
 
     def test_multiple_chip_names(self):
         """
@@ -105,27 +106,28 @@ class ChipNameTestCase(unittest.TestCase):
                                                 obs_metadata=obs)
 
         np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
-        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None') >= 0)[0]),
+                             n_obj/10)
 
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("rotSkyPos", context.exception.message)
 
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            _chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("mjd", context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            name = _chipNameFromRaDecLSST(ra_list, dec_list)
+            _chipNameFromRaDecLSST(ra_list, dec_list)
         self.assertIn("ObservationMetaData", context.exception.message)
 
         # check that exceptions are raised when ra_list, dec_list are of the wrong shape
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _chipNameFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+            _chipNameFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
         self.assertIn("chipNameFromRaDecLSST", context.exception.message)
 
     def test_chip_name_from_ra_dec_degrees(self):
@@ -152,27 +154,28 @@ class ChipNameTestCase(unittest.TestCase):
                                                obs_metadata=obs)
 
         np.testing.assert_array_equal(control_name_list.astype(str), test_name_list.astype(str))
-        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None')>=0)[0]), n_obj/10)
+        self.assertLessEqual(len(np.where(np.char.rfind(test_name_list.astype(str), 'None') >= 0)[0]),
+                             n_obj/10)
 
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
         with self.assertRaises(RuntimeError) as context:
-            name = chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("rotSkyPos", context.exception.message)
 
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
         with self.assertRaises(RuntimeError) as context:
-            name = chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            chipNameFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("mjd", context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            name = chipNameFromRaDecLSST(ra_list, dec_list)
+            chipNameFromRaDecLSST(ra_list, dec_list)
         self.assertIn("ObservationMetaData", context.exception.message)
 
         # check that exceptions are raised when ra_list, dec_list are of the wrong shape
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
         with self.assertRaises(RuntimeError) as context:
-            name = chipNameFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+            chipNameFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
         self.assertIn("chipNameFromRaDecLSST", context.exception.message)
 
     def test_pixel_coords_from_ra_dec_radians(self):
@@ -209,7 +212,6 @@ class ChipNameTestCase(unittest.TestCase):
         np.testing.assert_array_equal(x_pix, x_pix_test)
         np.testing.assert_array_equal(y_pix, y_pix_test)
 
-
         # test without distortion
         x_pix, y_pix = _pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
                                              includeDistortion=False)
@@ -224,22 +226,22 @@ class ChipNameTestCase(unittest.TestCase):
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("rotSkyPos", context.exception.message)
 
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            _pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("mjd", context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list)
+            _pixelCoordsFromRaDecLSST(ra_list, dec_list)
         self.assertIn("ObservationMetaData", context.exception.message)
 
         # check that exceptions are raised when ra_list, dec_list are of the wrong shape
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
         with self.assertRaises(RuntimeError) as context:
-            name = _pixelCoordsFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+            _pixelCoordsFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
         self.assertIn("pixelCoordsFromRaDecLSST", context.exception.message)
 
     def test_pixel_coords_from_ra_dec_degrees(self):
@@ -276,7 +278,6 @@ class ChipNameTestCase(unittest.TestCase):
         np.testing.assert_array_equal(x_pix, x_pix_test)
         np.testing.assert_array_equal(y_pix, y_pix_test)
 
-
         # test without distortion
         x_pix, y_pix = pixelCoordsFromRaDec(ra_list, dec_list, obs_metadata=obs, camera=self.camera,
                                             includeDistortion=False)
@@ -291,22 +292,22 @@ class ChipNameTestCase(unittest.TestCase):
         # test that exceptions are raised when incomplete ObservationMetaData are used
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, mjd=59580.0)
         with self.assertRaises(RuntimeError) as context:
-            name = pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("rotSkyPos", context.exception.message)
 
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=35.0)
         with self.assertRaises(RuntimeError) as context:
-            name = pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
+            pixelCoordsFromRaDecLSST(ra_list, dec_list, obs_metadata=obs)
         self.assertIn("mjd", context.exception.message)
 
         with self.assertRaises(RuntimeError) as context:
-            name = pixelCoordsFromRaDecLSST(ra_list, dec_list)
+            pixelCoordsFromRaDecLSST(ra_list, dec_list)
         self.assertIn("ObservationMetaData", context.exception.message)
 
         # check that exceptions are raised when ra_list, dec_list are of the wrong shape
         obs = ObservationMetaData(pointingRA=raP, pointingDec=decP, rotSkyPos=24.0, mjd=43000.0)
         with self.assertRaises(RuntimeError) as context:
-            name = pixelCoordsFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
+            pixelCoordsFromRaDecLSST(ra_list, dec_list[:5], obs_metadata=obs)
         self.assertIn("pixelCoordsFromRaDecLSST", context.exception.message)
 
 

--- a/ups/sims_coordUtils.table
+++ b/ups/sims_coordUtils.table
@@ -3,5 +3,6 @@ setupRequired(python)
 setupRequired(utils)
 setupRequired(afw)
 setupRequired(sims_utils)
+setupRequired(obs_lsstSim)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
The current chipNameFromPupilCoords() method is unnecessarily general.  It allows for the possibility that a single set of pupil coordinates could fall on more than one detector (in the LSST camera, this is only possible with pairs of wavefront sensors, since one wavefront sensor is kept in focus and the other is kept out of focus).  This generality is realized by looping over every pair of pupill coordinates and detector, to see if the detector contains the pupil coordinate, which slows down the code.  This PR adds a method chipNameFromPupilCoordsLSST() that, for each point in pupil coordinates, only considers detectors that are 1.1 detector radii away from the point.  This simplification achieves a factor of 6 to 7 speed up relative to chipNameFromPupilCoords().  
