### PR TITLE
U/danielsf/outside/radius

### DIFF
--- a/python/lsst/sims/coordUtils/LsstCameraUtils.py
+++ b/python/lsst/sims/coordUtils/LsstCameraUtils.py
@@ -367,7 +367,8 @@ def chipNameFromPupilCoordsLSST(xPupil_in, yPupil_in, allow_multiple_chips=False
     radius_sq_list = ((xFocal-chipNameFromPupilCoordsLSST._x_focal_center)**2 +
                       (yFocal-chipNameFromPupilCoordsLSST._y_focal_center)**2)
 
-    good_radii = np.where(radius_sq_list<chipNameFromPupilCoordsLSST._camera_focal_radius_sq)
+    with np.errstate(invalid='ignore'):
+        good_radii = np.where(radius_sq_list<chipNameFromPupilCoordsLSST._camera_focal_radius_sq)
 
     if len(good_radii[0]) == 0:
         return np.array([None]*len(xPupil_in))

--- a/python/lsst/sims/coordUtils/LsstZernikeFitter.py
+++ b/python/lsst/sims/coordUtils/LsstZernikeFitter.py
@@ -95,7 +95,12 @@ class LsstZernikeFitter(object):
         self._pixel_transformer = DMtoCameraPixelTransformer()
         self._z_gen = ZernikePolynomialGenerator()
 
-        self._rr = 450.0  # radius in mm of circle containing LSST focal plane
+        self._rr = 500.0  # radius in mm of circle containing LSST focal plane;
+                          # make it a little bigger to accommodate any slop in
+                          # the conversion from focal plane coordinates back to
+                          # pupil coordinates (in case the optical distortions
+                          # cause points to cross over the actual boundary of
+                          # the focal plane)
 
         self._band_to_int = {}
         self._band_to_int['u'] = 0

--- a/python/lsst/sims/coordUtils/LsstZernikeFitter.py
+++ b/python/lsst/sims/coordUtils/LsstZernikeFitter.py
@@ -5,7 +5,6 @@ import palpy
 
 from lsst.utils import getPackageDir
 from lsst.sims.utils import ZernikePolynomialGenerator
-from lsst.sims.utils import ZernikeRadialError
 from lsst.sims.coordUtils import lsst_camera
 from lsst.sims.coordUtils import DMtoCameraPixelTransformer
 from lsst.afw.cameraGeom import PIXELS, FOCAL_PLANE, FIELD_ANGLE, SCIENCE
@@ -135,15 +134,7 @@ class LsstZernikeFitter(object):
 
         polynomials = {}
         for n, m in zip(self._n_grid, self._m_grid):
-            try:
-                values = self._z_gen.evaluate_xy(x_in/self._rr, y_in/self._rr, n, m)
-            except ZernikeRadialError:
-                msg = "Some of the data you are fitting to in LsstZernikeFitter is outside "
-                msg += "the r = %e mm circle circumscribing the LSST focal plane. " % self._rr
-                msg += "The Zernike polynomials we are fitting to are not defined "
-                msg += "outside of that circle."
-                raise RuntimeError(msg)
-
+            values = self._z_gen.evaluate_xy(x_in/self._rr, y_in/self._rr, n, m)
             polynomials[(n,m)] = values
 
         poly_keys = list(polynomials.keys())
@@ -318,15 +309,7 @@ class LsstZernikeFitter(object):
             dy = np.zeros(len(ymm), dtype=float)
 
         for kk in self._pupil_to_focal[band]['x']:
-            try:
-                values = self._z_gen.evaluate_xy(xmm/self._rr, ymm/self._rr, kk[0], kk[1])
-            except ZernikeRadialError:
-                msg = "Some of the points you are transforming in LsstZernikeFitter are outside "
-                msg += "the r = %e mm circle circumscribing the LSST focal plane. " % self._rr
-                msg += "The Zernike polynomials we are fitting to are not defined "
-                msg += "outside of that circle."
-                raise RuntimeError(msg)
-
+            values = self._z_gen.evaluate_xy(xmm/self._rr, ymm/self._rr, kk[0], kk[1])
             dx += transformation_dict[band]['x'][kk]*values
             dy += transformation_dict[band]['y'][kk]*values
 

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -35,6 +35,26 @@ class ChipNameTestCase(unittest.TestCase):
         del cls.camera
         clean_up_lsst_camera()
 
+    def test_outside_radius(self):
+        """
+        Test that methods can gracefully handle points
+        outside of the focal plane
+        """
+        rng = np.random.RandomState(7123)
+        ra = 145.0
+        dec = -25.0
+        obs = ObservationMetaData(pointingRA=ra, pointingDec=dec,
+                                  mjd=59580.0, rotSkyPos=113.0)
+
+        rr = rng.random_sample(100)*5.0
+        self.assertGreater(rr.max(), 4.5)
+        theta = rng.random_sample(100)*2.0*np.pi
+        ra_vec = ra + rr*np.cos(theta)
+        dec_vec = dec + rr*np.sin(theta)
+        chip_name_list = chipNameFromRaDecLSST(ra_vec, dec_vec,
+                                               obs_metadata=obs,
+                                               band='u')
+
     def test_chip_center(self):
         """
         Test that, if we ask for the chip at the bore site,

--- a/tests/testLsstCameraUtils.py
+++ b/tests/testLsstCameraUtils.py
@@ -15,6 +15,7 @@ from lsst.sims.coordUtils import focalPlaneCoordsFromPupilCoordsLSST
 from lsst.sims.utils import pupilCoordsFromRaDec, radiansFromArcsec
 from lsst.sims.utils import ObservationMetaData
 from lsst.obs.lsstSim import LsstSimMapper
+from lsst.sims.utils import angularSeparation
 
 from lsst.sims.coordUtils import clean_up_lsst_camera
 
@@ -54,6 +55,15 @@ class ChipNameTestCase(unittest.TestCase):
         chip_name_list = chipNameFromRaDecLSST(ra_vec, dec_vec,
                                                obs_metadata=obs,
                                                band='u')
+
+        rr = angularSeparation(ra, dec, ra_vec, dec_vec)
+
+        ct_none = 0
+        for rr, name in zip(rr, chip_name_list):
+            if rr > 2.0:
+                self.assertIsNone(name)
+                ct_none += 1
+        self.assertGreater(ct_none, 0)
 
     def test_chip_center(self):
         """

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1075,6 +1075,9 @@ class FullTransformationTestCase(unittest.TestCase):
         xf = rr*np.cos(theta)
         yf = rr*np.sin(theta)
         xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(xf, yf, band='g')
+        xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp,
+                                                    chipName='R:2,2 S:1,1',
+                                                    band='g')
         invalid = np.where(rr>500.0)[0]
         self.assertGreater(len(invalid), 0)
         self.assertLess(len(invalid), n_samples)
@@ -1082,15 +1085,21 @@ class FullTransformationTestCase(unittest.TestCase):
             if ii in invalid:
                 self.assertTrue(np.isnan(xp[ii]))
                 self.assertTrue(np.isnan(yp[ii]))
+                self.assertTrue(np.isnan(xpix[ii]))
+                self.assertTrue(np.isnan(ypix[ii]))
             else:
                 self.assertFalse(np.isnan(xp[ii]))
                 self.assertFalse(np.isnan(yp[ii]))
+                self.assertFalse(np.isnan(xpix[ii]))
+                self.assertFalse(np.isnan(ypix[ii]))
 
         rr = rng.random_sample(n_samples)*0.05
         xp = rr*np.cos(theta)
         yp = rr*np.sin(theta)
 
         xf2, yf2 = focalPlaneCoordsFromPupilCoordsLSST(xp, yp, band='i')
+        xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp, chipName='R:2,2 S:1,1',
+                                                    band='i')
         invalid = np.where(rr>0.04841)[0]
         self.assertGreater(len(invalid), 0)
         self.assertLess(len(invalid), n_samples)
@@ -1098,9 +1107,53 @@ class FullTransformationTestCase(unittest.TestCase):
             if ii in invalid:
                 self.assertTrue(np.isnan(xf2[ii]))
                 self.assertTrue(np.isnan(yf2[ii]))
+                self.assertTrue(np.isnan(xpix[ii]))
+                self.assertTrue(np.isnan(ypix[ii]))
             else:
                 self.assertFalse(np.isnan(xf2[ii]))
                 self.assertFalse(np.isnan(yf2[ii]))
+                self.assertFalse(np.isnan(xpix[ii]))
+                self.assertFalse(np.isnan(ypix[ii]))
+
+        xf = np.array([1.1, 2.1, np.NaN, 4.5])
+        yf = np.array([2.1, np.NaN, 1.2, 3.0])
+        xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(xf, yf, band='r')
+        self.assertTrue(np.isnan(xp[2]))
+        self.assertTrue(np.isnan(yp[2]))
+        self.assertTrue(np.isnan(xp[1]))
+        self.assertTrue(np.isnan(yp[1]))
+        self.assertFalse(np.isnan(xp[0]))
+        self.assertFalse(np.isnan(yp[0]))
+        self.assertFalse(np.isnan(xp[3]))
+        self.assertFalse(np.isnan(yp[3]))
+
+        xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(np.NaN, 1.0, band='g')
+        self.assertTrue(np.isnan(xp))
+        self.assertTrue(np.isnan(yp))
+
+        xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(2.1, np.NaN, band='g')
+        self.assertTrue(np.isnan(xp))
+        self.assertTrue(np.isnan(yp))
+
+        xp = np.array([0.0011, 0.0021, np.NaN, 0.0045])
+        yp = np.array([0.0021, np.NaN, 0.0012, 0.0030])
+        xf, yf = focalPlaneCoordsFromPupilCoordsLSST(xp, yp, band='r')
+        self.assertTrue(np.isnan(xf[2]))
+        self.assertTrue(np.isnan(yf[2]))
+        self.assertTrue(np.isnan(xf[1]))
+        self.assertTrue(np.isnan(yf[1]))
+        self.assertFalse(np.isnan(xf[0]))
+        self.assertFalse(np.isnan(yf[0]))
+        self.assertFalse(np.isnan(xf[3]))
+        self.assertFalse(np.isnan(yf[3]))
+
+        xf, yf = focalPlaneCoordsFromPupilCoordsLSST(np.NaN, 0.001, band='g')
+        self.assertTrue(np.isnan(xf))
+        self.assertTrue(np.isnan(yf))
+
+        xf, yf = pupilCoordsFromFocalPlaneCoordsLSST(0.002, np.NaN, band='g')
+        self.assertTrue(np.isnan(xf))
+        self.assertTrue(np.isnan(yf))
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1078,20 +1078,30 @@ class FullTransformationTestCase(unittest.TestCase):
         xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp,
                                                     chipName='R:2,2 S:1,1',
                                                     band='g')
+
+        xpix2, ypix2 = pixelCoordsFromPupilCoordsLSST(xp, yp,
+                                                      band='g')
         invalid = np.where(rr>500.0)[0]
         self.assertGreater(len(invalid), 0)
         self.assertLess(len(invalid), n_samples)
+        non_nan_pix = 0
         for ii in range(n_samples):
             if ii in invalid:
                 self.assertTrue(np.isnan(xp[ii]))
                 self.assertTrue(np.isnan(yp[ii]))
                 self.assertTrue(np.isnan(xpix[ii]))
                 self.assertTrue(np.isnan(ypix[ii]))
+                self.assertTrue(np.isnan(xpix2[ii]))
+                self.assertTrue(np.isnan(ypix2[ii]))
             else:
                 self.assertFalse(np.isnan(xp[ii]))
                 self.assertFalse(np.isnan(yp[ii]))
                 self.assertFalse(np.isnan(xpix[ii]))
                 self.assertFalse(np.isnan(ypix[ii]))
+                if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
+                    non_nan_pix += 1
+
+        self.assertGreater(non_nan_pix, 0)
 
         rr = rng.random_sample(n_samples)*0.05
         xp = rr*np.cos(theta)
@@ -1100,20 +1110,30 @@ class FullTransformationTestCase(unittest.TestCase):
         xf2, yf2 = focalPlaneCoordsFromPupilCoordsLSST(xp, yp, band='i')
         xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp, chipName='R:2,2 S:1,1',
                                                     band='i')
+        xpix2, ypix2 = pixelCoordsFromPupilCoordsLSST(xp, yp,
+                                                      band='g')
+
         invalid = np.where(rr>0.04841)[0]
         self.assertGreater(len(invalid), 0)
         self.assertLess(len(invalid), n_samples)
+        non_nan_pix = 0
         for ii in range(n_samples):
             if ii in invalid:
                 self.assertTrue(np.isnan(xf2[ii]))
                 self.assertTrue(np.isnan(yf2[ii]))
                 self.assertTrue(np.isnan(xpix[ii]))
                 self.assertTrue(np.isnan(ypix[ii]))
+                self.assertTrue(np.isnan(xpix2[ii]))
+                self.assertTrue(np.isnan(ypix2[ii]))
             else:
                 self.assertFalse(np.isnan(xf2[ii]))
                 self.assertFalse(np.isnan(yf2[ii]))
                 self.assertFalse(np.isnan(xpix[ii]))
                 self.assertFalse(np.isnan(ypix[ii]))
+                if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
+                    non_nan_pix += 1
+
+        self.assertGreater(non_nan_pix, 0)
 
         xf = np.array([1.1, 2.1, np.NaN, 4.5])
         yf = np.array([2.1, np.NaN, 1.2, 3.0])

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1062,6 +1062,46 @@ class FullTransformationTestCase(unittest.TestCase):
                     self.assertEqual(ra1, ra_rad[ii])
                     self.assertEqual(dec1, dec_rad[ii])
 
+    def test_nans(self):
+        """
+        Test that points outside the focal plane get NaNs for pupil
+        and focal plane coords
+        """
+        rng = np.random.RandomState(66)
+        n_samples = 100
+        rr = rng.random_sample(n_samples)*600.0
+        theta = rng.random_sample(n_samples)*2.0*np.pi
+        self.assertGreater(rr.max(), 500.0)
+        xf = rr*np.cos(theta)
+        yf = rr*np.sin(theta)
+        xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(xf, yf, band='g')
+        invalid = np.where(rr>500.0)[0]
+        self.assertGreater(len(invalid), 0)
+        self.assertLess(len(invalid), n_samples)
+        for ii in range(n_samples):
+            if ii in invalid:
+                self.assertTrue(np.isnan(xp[ii]))
+                self.assertTrue(np.isnan(yp[ii]))
+            else:
+                self.assertFalse(np.isnan(xp[ii]))
+                self.assertFalse(np.isnan(yp[ii]))
+
+        rr = rng.random_sample(n_samples)*0.05
+        xp = rr*np.cos(theta)
+        yp = rr*np.sin(theta)
+
+        xf2, yf2 = focalPlaneCoordsFromPupilCoordsLSST(xp, yp, band='i')
+        invalid = np.where(rr>0.04841)[0]
+        self.assertGreater(len(invalid), 0)
+        self.assertLess(len(invalid), n_samples)
+        for ii in range(n_samples):
+            if ii in invalid:
+                self.assertTrue(np.isnan(xf2[ii]))
+                self.assertTrue(np.isnan(yf2[ii]))
+            else:
+                self.assertFalse(np.isnan(xf2[ii]))
+                self.assertFalse(np.isnan(yf2[ii]))
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1109,6 +1109,11 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertFalse(np.isnan(ypix[ii]))
                 self.assertFalse(np.isnan(ra[ii]))
                 self.assertFalse(np.isnan(dec[ii]))
+
+                # this test is because, even if an object
+                # has finite pupil or focal plane coordinates,
+                # it could still land in a chip gap, causing
+                # chip_name=None, xpix=ypix=NaN
                 if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
                     non_nan_pix += 1
                 if name_list[ii] is not None:
@@ -1153,6 +1158,11 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertFalse(np.isnan(ypix[ii]))
                 self.assertFalse(np.isnan(ra[ii]))
                 self.assertFalse(np.isnan(dec[ii]))
+
+                # this test is because, even if an object
+                # has finite pupil or focal plane coordinates,
+                # it could still land in a chip gap, causing
+                # chip_name=None, xpix=ypix=NaN
                 if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
                     non_nan_pix += 1
 

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1079,6 +1079,10 @@ class FullTransformationTestCase(unittest.TestCase):
                                                     chipName='R:2,2 S:1,1',
                                                     band='g')
 
+        ra, dec = raDecFromPixelCoordsLSST(xpix, ypix, 'R:2,2 S:1,1',
+                                           obs_metadata=self._obs,
+                                           band='g')
+
         xpix2, ypix2 = pixelCoordsFromPupilCoordsLSST(xp, yp,
                                                       band='g')
         invalid = np.where(rr>500.0)[0]
@@ -1093,11 +1097,15 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertTrue(np.isnan(ypix[ii]))
                 self.assertTrue(np.isnan(xpix2[ii]))
                 self.assertTrue(np.isnan(ypix2[ii]))
+                self.assertTrue(np.isnan(ra[ii]))
+                self.assertTrue(np.isnan(dec[ii]))
             else:
                 self.assertFalse(np.isnan(xp[ii]))
                 self.assertFalse(np.isnan(yp[ii]))
                 self.assertFalse(np.isnan(xpix[ii]))
                 self.assertFalse(np.isnan(ypix[ii]))
+                self.assertFalse(np.isnan(ra[ii]))
+                self.assertFalse(np.isnan(dec[ii]))
                 if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
                     non_nan_pix += 1
 
@@ -1110,6 +1118,11 @@ class FullTransformationTestCase(unittest.TestCase):
         xf2, yf2 = focalPlaneCoordsFromPupilCoordsLSST(xp, yp, band='i')
         xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp, chipName='R:2,2 S:1,1',
                                                     band='i')
+
+        ra, dec = raDecFromPixelCoordsLSST(xpix, ypix, 'R:2,2 S:1,1',
+                                           obs_metadata=self._obs,
+                                           band='i')
+
         xpix2, ypix2 = pixelCoordsFromPupilCoordsLSST(xp, yp,
                                                       band='g')
 
@@ -1125,11 +1138,15 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertTrue(np.isnan(ypix[ii]))
                 self.assertTrue(np.isnan(xpix2[ii]))
                 self.assertTrue(np.isnan(ypix2[ii]))
+                self.assertTrue(np.isnan(ra[ii]))
+                self.assertTrue(np.isnan(dec[ii]))
             else:
                 self.assertFalse(np.isnan(xf2[ii]))
                 self.assertFalse(np.isnan(yf2[ii]))
                 self.assertFalse(np.isnan(xpix[ii]))
                 self.assertFalse(np.isnan(ypix[ii]))
+                self.assertFalse(np.isnan(ra[ii]))
+                self.assertFalse(np.isnan(dec[ii]))
                 if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
                     non_nan_pix += 1
 

--- a/tests/testLsstOpticalDistortions.py
+++ b/tests/testLsstOpticalDistortions.py
@@ -1075,6 +1075,7 @@ class FullTransformationTestCase(unittest.TestCase):
         xf = rr*np.cos(theta)
         yf = rr*np.sin(theta)
         xp, yp = pupilCoordsFromFocalPlaneCoordsLSST(xf, yf, band='g')
+        name_list = chipNameFromPupilCoordsLSST(xp, yp, band='g')
         xpix, ypix = pixelCoordsFromPupilCoordsLSST(xp, yp,
                                                     chipName='R:2,2 S:1,1',
                                                     band='g')
@@ -1089,6 +1090,7 @@ class FullTransformationTestCase(unittest.TestCase):
         self.assertGreater(len(invalid), 0)
         self.assertLess(len(invalid), n_samples)
         non_nan_pix = 0
+        non_none_name = 0
         for ii in range(n_samples):
             if ii in invalid:
                 self.assertTrue(np.isnan(xp[ii]))
@@ -1099,6 +1101,7 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertTrue(np.isnan(ypix2[ii]))
                 self.assertTrue(np.isnan(ra[ii]))
                 self.assertTrue(np.isnan(dec[ii]))
+                self.assertIsNone(name_list[ii])
             else:
                 self.assertFalse(np.isnan(xp[ii]))
                 self.assertFalse(np.isnan(yp[ii]))
@@ -1108,8 +1111,11 @@ class FullTransformationTestCase(unittest.TestCase):
                 self.assertFalse(np.isnan(dec[ii]))
                 if not np.isnan(xpix2[ii]) and not np.isnan(ypix2[ii]):
                     non_nan_pix += 1
+                if name_list[ii] is not None:
+                    non_none_name += 1
 
         self.assertGreater(non_nan_pix, 0)
+        self.assertGreater(non_none_name, 0)
 
         rr = rng.random_sample(n_samples)*0.05
         xp = rr*np.cos(theta)


### PR DESCRIPTION
In responding to the PR for `u/danielsf/fix/focal/plane`, I set up a system where, if you asked for the focal plane coordinates of something well outside of the LSST focal plane, you got a `ZernikeRadialError`.  This would have caused a problem for us in image simulation, where we routinely ask for catalogs that are larger than the focal plane and let the image simulator figure out which objects are in and out of the focal plane.

This PR changes the behavior of `ZernikePolynomialGenerator` so that it will return `np.NaN` for any point that is outside of the LSST focal plane.  The routines in sims_coordUtils that find pixel positions and chip names will no how to deal with this.